### PR TITLE
.hack file support part 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-hack",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -743,6 +743,11 @@
         "rimraf": "2"
       }
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -1154,6 +1159,14 @@
         "har-schema": "^2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -1209,10 +1222,9 @@
       "dev": true
     },
     "is": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
-      "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
-      "dev": true
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -1639,12 +1651,12 @@
       }
     },
     "node.extend": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
-      "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
-      "dev": true,
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
+      "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
       "requires": {
-        "is": "^3.1.0"
+        "has": "^1.0.3",
+        "is": "^3.2.1"
       }
     },
     "nopt": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-hack",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "publisher": "pranayagarwal",
   "engines": {
     "vscode": "^1.25.0"
@@ -49,7 +49,8 @@
         "configuration": "./hack.configuration.json",
         "extensions": [
           ".php",
-          ".hh"
+          ".hh",
+          ".hack"
         ],
         "firstLine": "^<\\?hh\\b.*|#!.*hhvm.*$"
       },

--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -3,7 +3,8 @@
   "name": "HACK",
   "fileTypes": [
     "hh",
-    "php"
+    "php",
+    "hack"
   ],
   "firstLineMatch": "<?hh",
   "foldingStartMarker": "(/\\*|\\{\\s*$|<<<HTML)",


### PR DESCRIPTION
Lets VS Code detect `.hack` files as Hack. The `<?hh` opener is still needed for syntax highlighting though at the moment.