### PR TITLE
Syntax highlighting support for .hack files

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "grammars": [
       {
         "language": "hack",
-        "scopeName": "text.html.hack",
+        "scopeName": "source.hack",
         "path": "./syntaxes/hack.json"
       }
     ],

--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -1,16 +1,15 @@
 {
-  "scopeName": "text.html.hack",
-  "name": "HACK",
+  "scopeName": "source.hack",
+  "name": "Hack",
   "fileTypes": [
     "hh",
     "php",
     "hack"
   ],
-  "firstLineMatch": "<?hh",
   "foldingStartMarker": "(/\\*|\\{\\s*$|<<<HTML)",
   "foldingStopMarker": "(\\*/|^\\s*\\}|^HTML;)",
   "injections": {
-    "text.html.hack - (meta.embedded | meta.tag), L:text.html.hack meta.tag, L:source.js.embedded.html": {
+    "source.hack - (meta.embedded | meta.tag), L:source.hack meta.tag, L:source.js.embedded.html": {
       "patterns": [
         {
           "begin": "(^\\s*)(?=<\\?(?![^?]*\\?>))",
@@ -132,6 +131,9 @@
   "patterns": [
     {
       "include": "text.html.basic"
+    },
+    {
+      "include": "#language"
     }
   ],
   "repository": {


### PR DESCRIPTION
Change 2/2 for .hack file support. Now syntax highlighting works as normal for files recognized as Hack even without the opening `<?hh`.

This is all that should be needed for https://github.com/slackhq/vscode-hack/issues/35.