### PR TITLE
Support for remote language server connection via SSH or Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ It is published in the Visual Studio Marketplace [here](https://marketplace.visu
 
 ## v2.0.0
 * **Remote development support** — You can now connect to an external development environment for Hack typechecking, linting and all other intellisense features. Current supported methods are SSH and Docker. See the **Remote Development** section below for more details.
-* This version may cause breaking changes to your existing setup if you were already using Docker via a custom `hack.clientPath` executable.
-* The `hack.workspaceRootPath` config has been renamed to `hack.remote.workspacePath`.
+  * This version may cause breaking changes to your existing setup if you were already using Docker via a custom `hack.clientPath` executable.
+  * The `hack.workspaceRootPath` config has been renamed to `hack.remote.workspacePath`.
 * Running the extension with LSP mode disabled is now unsupported. It will be fully removed in a future version of the extension.
 
 ## v1.2.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It is published in the Visual Studio Marketplace [here](https://marketplace.visu
 ## Latest releases
 
 ## v2.0.0
-* **Remote development support** — You can now connect to an external development environment for Hack typechecking, linting and all other intellisense features. Current supported methods are SSH and Docker. See the **Remote Development** section below for more details.
+* **Remote language server connection support** — You can now connect to an external development environment for Hack typechecking, linting and all other intellisense features. Current supported methods are SSH and Docker. See the **Remote Development** section below for more details.
   * This version may cause breaking changes to your existing setup if you were already using Docker via a custom `hack.clientPath` executable.
   * The `hack.workspaceRootPath` config has been renamed to `hack.remote.workspacePath`.
 * Running the extension with LSP mode disabled is now unsupported. It will be fully removed in a future version of the extension.
@@ -54,7 +54,7 @@ This extension adds the following Visual Studio Code settings. These can be set 
 
 ### Remote Development
 
-The extension supports connecting to an external HHVM development environment for local typechecking, linting and all other intellisense features. The current supported methods are SSH into a remote host or exec in a local Docker container.
+The extension supports connecting to an external HHVM development environment for local typechecking, linting and all other intellisense features. The current supported connection methods are SSH into a remote host or exec in a local Docker container.
 
 To enable this, set the following config values:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-hack",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "publisher": "pranayagarwal",
   "engines": {
     "vscode": "^1.25.0"
@@ -175,13 +175,14 @@
       "properties": {
         "hack.clientPath": {
           "type": "string",
-          "default": null,
-          "description": "Absolute path to the hh_client executable. This can be left empty if hh_client is already in your environment $PATH. A `docker exec` command is supported as well."
+          "default": "hh_client",
+          "description": "Absolute path to the hh_client executable. This can be left empty if hh_client is already in your environment $PATH."
         },
         "hack.workspaceRootPath": {
           "type": "string",
           "default": null,
-          "description": "Absolute path to the workspace root directory. This will be the VS Code workspace root by default, but can be changed if the project is in a subdirectory or mounted in a Docker container."
+          "description": "Absolute path to the workspace root directory. This will be the VS Code workspace root by default, but can be changed if the project is in a subdirectory or mounted in a Docker container.",
+          "deprecationMessage": "Use hack.remote.workspacePath instead"
         },
         "hack.enableCoverageCheck": {
           "type": "boolean",
@@ -196,12 +197,14 @@
         "hack.useHhast": {
           "type": "boolean",
           "default": true,
-          "description": "Automatically invoke HHAST"
+          "description": "Enable linting (needs HHAST library set up and configured in project)",
+          "markdownDescription": "Enable linting (needs [HHAST](https://github.com/hhvm/hhast) library set up and configured in project)"
         },
         "hack.hhastPath": {
           "type": "string",
           "default": "vendor/bin/hhast-lint",
-          "description": "Path to hhast-lint executable. Only works for HHAST 3.27.1 and above"
+          "description": "Use an alternate hhast-lint path. Can be abolute or relative to workspace root.",
+          "markdownDescription": "Use an alternate `hhast-lint` path. Can be abolute or relative to workspace root."
         },
         "hack.hhastArgs": {
           "type": "array",
@@ -209,7 +212,7 @@
             "type": "string"
           },
           "default": [],
-          "description": "Additional arguments to pass to hhast-lint"
+          "description": "Optional list of arguments passed to hhast-lint executable"
         },
         "hack.hhastLintMode": {
           "type": "string",
@@ -217,8 +220,12 @@
             "whole-project",
             "open-files"
           ],
+          "enumDescriptions": [
+            "Lint the entire project and show all errors",
+            "Only lint the currently open files"
+          ],
           "default": null,
-          "description": "Whether to lint the whole project, or just open files"
+          "description": "Whether to lint the entire project or just the open files"
         },
         "hack.rememberedWorkspaces": {
           "type": "object",
@@ -232,6 +239,39 @@
           "default": {},
           "description": "Workspaces where whether or not to run custom Hack executables (e.g. hhast-lint) has been remembered"
         },
+        "hack.remote.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Run the Hack language tools on an external host"
+        },
+        "hack.remote.type": {
+          "type": "string",
+          "enum": [
+            "ssh",
+            "docker"
+          ],
+          "enumDescriptions": [
+            "Run typechecker on a remote server via SSH",
+            "Run typechecker in a Docker container"
+          ],
+          "description": "The remote connection method"
+        },
+        "hack.remote.workspacePath": {
+          "type": "string",
+          "description": "Absolute location of workspace root in the remote file system"
+        },
+        "hack.remote.ssh.host": {
+          "type": "string",
+          "description": "Address for the remote development server to connect to (in the format `[user@]hostname`)"
+        },
+        "hack.remote.ssh.flags": {
+          "type": "array",
+          "description": "Additional command line options to pass when establishing the SSH connection"
+        },
+        "hack.remote.docker.containerName": {
+          "type": "string",
+          "description": "Name of the local Docker container to run the language tools in"
+        },
         "hack.trace.server": {
           "type": "string",
           "scope": "window",
@@ -241,7 +281,7 @@
             "verbose"
           ],
           "default": "off",
-          "description": "Traces the communication between VS Code and the Hack language server."
+          "description": "Traces the communication between VS Code and the Hack & HHAST language servers"
         }
       }
     },

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -7,42 +7,13 @@ import * as vscode from 'vscode';
 
 const hackConfig = vscode.workspace.getConfiguration('hack');
 
-export const clientPath: string = hackConfig.get('clientPath') || 'hh_client';
-export const hhClientArgs: string[] = clientPath.split(' ');
-export const hhClientCommand: string = String(hhClientArgs.shift());
-
-export let mapWorkspace: boolean = false;
-export let workspace: string;
-const workspaceRootPath: string | undefined = hackConfig.get('workspaceRootPath');
-if (workspaceRootPath) {
-    mapWorkspace = true;
-    workspace = workspaceRootPath;
-} else if (vscode.workspace.workspaceFolders) {
-    workspace = vscode.workspace.workspaceFolders[0].uri.fsPath;
-}
-
-let enableCoverageCheckConfig: boolean | undefined = hackConfig.get('enableConverageCheck');
-if (enableCoverageCheckConfig === undefined) {
-    enableCoverageCheckConfig = true;
-}
-export const enableCoverageCheck: boolean = enableCoverageCheckConfig;
-
-let useLanguageServerConfig: boolean | undefined = hackConfig.get('useLanguageServer');
-if (useLanguageServerConfig === undefined) {
-    useLanguageServerConfig = true;
-}
-export const useLanguageServer: boolean = useLanguageServerConfig;
-
-let useHhastConfig: boolean | undefined = hackConfig.get('useHhast');
-if (useHhastConfig === undefined) {
-    useHhastConfig = true;
-}
-export const useHhast: boolean = useHhastConfig;
-
-export const hhastLintMode: 'whole-project' | 'open-files' | undefined | null = hackConfig.get('hhastLintMode');
-
-export const hhastPath: string | undefined = hackConfig.get('hhastPath');
-export const hhastArgs: string[] = hackConfig.get('hhastArgs') || [];
+export const clientPath = hackConfig.get<string>('clientPath') || 'hh_client';
+export const enableCoverageCheck = hackConfig.get<boolean>('enableConverageCheck', true);
+export const useLanguageServer = hackConfig.get<boolean>('useLanguageServer', true);
+export const useHhast = hackConfig.get<boolean>('useHhast', true);
+export const hhastLintMode: 'whole-project' | 'open-files' = hackConfig.get('hhastLintMode', 'whole-project');
+export const hhastPath = hackConfig.get<string>('hhastPath') || '/vendor/bin/hhast-lint';
+export const hhastArgs = hackConfig.get<string[]>('hhastArgs', []);
 
 // Use the global configuration so that a project can't both provide a malicious hhast-lint executable and whitelist itself in $project/.vscode/settings.json
 const hhastRemembered: { globalValue?: { [key: string]: 'trusted' | 'untrusted' } } | undefined = hackConfig.inspect('rememberedWorkspaces');
@@ -53,3 +24,13 @@ export async function rememberHhastWorkspace(newWorkspace: string, trust: 'trust
     remembered[newWorkspace] = trust;
     await hackConfig.update('rememberedWorkspaces', remembered, vscode.ConfigurationTarget.Global);
 }
+
+// tslint:disable-next-line:no-non-null-assertion
+export const localWorkspacePath = vscode.workspace.workspaceFolders![0].uri.fsPath;
+
+export const remoteEnabled = hackConfig.get<boolean>('remote.enabled', false);
+export const remoteType: 'ssh' | 'docker' | undefined = hackConfig.get('remote.type', undefined);
+export const remoteWorkspacePath = hackConfig.get<string>('remote.workspacePath');
+export const sshHost = hackConfig.get<string>('remote.ssh.host', '');
+export const sshArgs = hackConfig.get<string[]>('remote.ssh.args', []);
+export const dockerContainerName = hackConfig.get<string>('remote.docker.containerName', '');

--- a/src/LSPHackTypeChecker.ts
+++ b/src/LSPHackTypeChecker.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import { HandleDiagnosticsSignature, LanguageClient, RevealOutputChannelOn } from 'vscode-languageclient';
 import * as config from './Config';
 import { HackCoverageChecker } from './coveragechecker';
+import * as remote from './remote';
 import * as hack from './types/hack';
 import * as utils from './Utils';
 
@@ -24,8 +25,8 @@ export class LSPHackTypeChecker {
     const context = this.context;
 
     const serverOptions = {
-      command: config.hhClientCommand,
-      args: [...config.hhClientArgs, 'lsp', '--from', 'vscode-hack']
+      command: remote.getCommand(config.clientPath),
+      args: remote.getArgs(config.clientPath, ['lsp', '--from', 'vscode-hack'])
     };
 
     const clientOptions =  {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -11,18 +11,11 @@ import * as config from './Config';
  * @param file The file URI to convert
  * @param includeScheme Whether to include the file:// scheme in the response or not
  */
-export const mapFromWorkspaceUri = (file: vscode.Uri, includeScheme: boolean = true): string => {
-    if (!config.mapWorkspace && includeScheme) {
+export const mapFromWorkspaceUri = (file: vscode.Uri): string => {
+    if (!config.remoteEnabled || !config.remoteWorkspacePath) {
         return file.toString();
     }
-    let filePath = file.fsPath;
-    if (config.mapWorkspace && vscode.workspace.workspaceFolders) {
-        filePath = filePath.replace(vscode.workspace.workspaceFolders[0].uri.fsPath, config.workspace);
-    }
-    if (includeScheme) {
-        return vscode.Uri.file(filePath).toString();
-    }
-    return filePath;
+    return file.toString().replace(config.localWorkspacePath, config.remoteWorkspacePath);
 };
 
 /**
@@ -32,8 +25,8 @@ export const mapFromWorkspaceUri = (file: vscode.Uri, includeScheme: boolean = t
  */
 export const mapToWorkspaceUri = (file: string): vscode.Uri => {
     let filePath = file;
-    if (config.mapWorkspace && vscode.workspace.workspaceFolders) {
-        filePath = filePath.replace(config.workspace, vscode.workspace.workspaceFolders[0].uri.fsPath);
+    if (config.remoteEnabled && config.remoteWorkspacePath) {
+        filePath = filePath.replace(config.remoteWorkspacePath, config.localWorkspacePath);
     }
     if (filePath.startsWith('file://')) {
         return vscode.Uri.parse(filePath);

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -73,7 +73,7 @@ export class HackHoverProvider implements vscode.HoverProvider {
         const startPosition = wordPosition.start;
         const line: number = startPosition.line + 1;
         const character: number = startPosition.character + 1;
-        return hh_client.typeAtPos(utils.mapFromWorkspaceUri(document.uri, false), line, character).then(hoverType => {
+        return hh_client.typeAtPos(utils.mapFromWorkspaceUri(document.uri), line, character).then(hoverType => {
             if (!hoverType) {
                 return;
             }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,6 +4,7 @@
 
 import * as ps from 'child_process';
 import * as config from './Config';
+import * as remote from './remote';
 import * as hack from './types/hack';
 
 export async function version(): Promise<hack.Version | undefined> {
@@ -62,8 +63,10 @@ export async function format(text: string, startPos: number, endPos: number): Pr
 
 async function run(extraArgs: string[], stdin?: string): Promise<any> {
     return new Promise<any>((resolve, _) => {
-        const args: string[] = [...config.hhClientArgs, ...extraArgs, '--json', '--from', 'vscode-hack', config.workspace];
-        const p = ps.execFile(config.hhClientCommand, args, { maxBuffer: 1024 * 1024 }, (err: any, stdout, stderr) => {
+        const workspacePath = (config.remoteEnabled && config.remoteWorkspacePath) ? config.remoteWorkspacePath : config.localWorkspacePath;
+        const command = remote.getCommand(config.clientPath);
+        const args = remote.getArgs(config.clientPath, [...extraArgs, '--json', '--from', 'vscode-hack', workspacePath]);
+        const p = ps.execFile(command, args, { maxBuffer: 1024 * 1024 }, (err: any, stdout, stderr) => {
             if (err !== null && err.code !== 0 && err.code !== 2) {
                 // any hh_client failure other than typecheck errors
                 console.error(`Hack: hh_client execution error: ${err}`);

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -1,0 +1,35 @@
+/**
+ * @file Helpers for remote connections to hh_client and hhast-lint
+ */
+
+import * as config from './Config';
+
+export function getCommand(command: string): string {
+    if (!config.remoteEnabled) {
+        return command;
+    }
+
+    if (config.remoteType === 'ssh') {
+        return 'ssh';
+    } else if (config.remoteType === 'docker') {
+        return 'docker';
+    } else {
+        // Error for unrecognized remote type
+        return command;
+    }
+}
+
+export function getArgs(command: string, args: string[]): string[] {
+    if (!config.remoteEnabled) {
+        return args;
+    }
+
+    if (config.remoteType === 'ssh') {
+        return [ ...config.sshArgs, config.sshHost, command, ...args ];
+    } else if (config.remoteType === 'docker') {
+        return [ 'exec', '-i', config.dockerContainerName, command, ...args ];
+    } else {
+        // Error for unrecognized remote type
+        return args;
+    }
+}


### PR DESCRIPTION
You can now connect to an external development environment for Hack typechecking, linting and all other intellisense features. Current supported methods are SSH and Docker. See the Remote Development section in README for more details.