### PR TITLE
recognize `async` as a storage modifier

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -926,12 +926,12 @@
           ]
         },
         {
-          "begin": "(?x)\n\\s*((?:(?:final|abstract|public|private|protected|static)\\s+)*)\n(function)\n(?:\\s+|(\\s*&\\s*))\n(?:\n  (__(?:call|construct|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic)(?=[^a-zA-Z0-9_\\x7f-\\xff]))\n  |\n  ([a-zA-Z0-9_]+)\n)",
+          "begin": "(?x)\n\\s*((?:(?:final|abstract|public|private|protected|static|async)\\s+)*)\n(function)\n(?:\\s+|(\\s*&\\s*))\n(?:\n  (__(?:call|construct|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic)(?=[^a-zA-Z0-9_\\x7f-\\xff]))\n  |\n  ([a-zA-Z0-9_]+)\n)",
           "beginCaptures": {
             "1": {
               "patterns": [
                 {
-                  "match": "final|abstract|public|private|protected|static",
+                  "match": "final|abstract|public|private|protected|static|async",
                   "name": "storage.modifier.php"
                 }
               ]


### PR DESCRIPTION
```hack
// async should be highlighted
// the same way as `public`, `private`, `protected`, `abstract`, `static` and `final`
async function foo(): Awaitable<string> {
  return 'bar';
}
```