### PR TITLE
Fix syntax error for endCaptures

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -298,7 +298,9 @@
               "begin": "(shape\\()",
               "end": "(=>)",
               "endCaptures": {
-                "1": "keyword.operator.key.php"
+                "1": {
+                  "name": "keyword.operator.key.php"
+                }
               },
               "patterns": [
                 {


### PR DESCRIPTION
We'd like to use this grammar to highlight Hack code on GitHub.com (cf. github/linguist#4466). Unfortunately, in its current version, the grammar is rejected by our compiler due to a syntax error. This pull request fixes it.

/cc @azjezz 