### PR TITLE
Prompt to reload extension on certain config updates

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -34,3 +34,13 @@ export const remoteWorkspacePath = hackConfig.get<string>('remote.workspacePath'
 export const sshHost = hackConfig.get<string>('remote.ssh.host', '');
 export const sshArgs = hackConfig.get<string[]>('remote.ssh.args', []);
 export const dockerContainerName = hackConfig.get<string>('remote.docker.containerName', '');
+
+// Prompt to reload workspace on certain configuration updates
+vscode.workspace.onDidChangeConfiguration(async event => {
+    if (event.affectsConfiguration('hack.remote')) {
+        const selection = await vscode.window.showInformationMessage('Please reload your workspace to apply the latest Hack configuration changes.', { modal: true }, 'Reload');
+        if (selection === 'Reload') {
+            vscode.commands.executeCommand('workbench.action.reloadWindow');
+        }
+    }
+});

--- a/tslint.json
+++ b/tslint.json
@@ -30,6 +30,7 @@
     // these rules require type info
     "no-unsafe-any": false,
     "strict-boolean-expressions": false,
-    "completed-docs": false
+    "completed-docs": false,
+    "await-promise": false
   }
 }


### PR DESCRIPTION
Fixes https://github.com/slackhq/vscode-hack/issues/47. Whenever a `hack.remote.*` config is updated, the user will see a modal prompting them to reload the extension. This can be easily extended to other config paths, but sticking to remote for now.

![image](https://user-images.githubusercontent.com/341507/57263020-d880d980-7023-11e9-98a9-bf43f7dbd3cc.png)
