### PR TITLE
Update elseif snippet

### DIFF
--- a/snippets/hack.json
+++ b/snippets/hack.json
@@ -54,7 +54,7 @@
     },
     "elseif …": {
       "prefix": "elseif",
-      "body": "elseif (${1:condition}) {\n\t${0:# code...}\n}"
+      "body": "else if (${1:condition}) {\n\t${0:# code...}\n}"
     },
     "for …": {
       "prefix": "for",


### PR DESCRIPTION
Using the elseif snippet with Facebook\HHAST\Linters\NoElseifLinter causes the linter to complain that you should put a space between else and if. This patch chanes the behavior of the elseif snippet to match the linter.