### PR TITLE
Disable coverage check for non-Hack files

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 const hackConfig = vscode.workspace.getConfiguration('hack');
 
 export const clientPath = hackConfig.get<string>('clientPath') || 'hh_client';
-export const enableCoverageCheck = hackConfig.get<boolean>('enableConverageCheck', true);
+export const enableCoverageCheck = hackConfig.get<boolean>('enableCoverageCheck', true);
 export const useLanguageServer = hackConfig.get<boolean>('useLanguageServer', true);
 export const useHhast = hackConfig.get<boolean>('useHhast', true);
 export const hhastLintMode: 'whole-project' | 'open-files' = hackConfig.get('hhastLintMode', 'whole-project');

--- a/src/coveragechecker.ts
+++ b/src/coveragechecker.ts
@@ -76,7 +76,7 @@ export class HackCoverageChecker {
 
         let coverageResponse: CoverageResponse;
         try {
-            coverageResponse = await this.languageClient.sendRequest(
+            coverageResponse = <CoverageResponse>await this.languageClient.sendRequest(
                 'textDocument/typeCoverage',
                 { textDocument: this.languageClient.code2ProtocolConverter.asTextDocumentIdentifier(document) }
             );

--- a/src/coveragechecker.ts
+++ b/src/coveragechecker.ts
@@ -36,21 +36,21 @@ export class HackCoverageChecker {
 
     public async start(context: vscode.ExtensionContext) {
 
-        context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(doc => this.check(doc)));
-        context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(editor => {
-            this.hhvmCoverDiag.clear();
+        context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(async doc => this.check(doc)));
+        context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(async editor => {
             if (editor) {
-                this.check(editor.document);
+                await this.check(editor.document);
             } else {
+                this.hhvmCoverDiag.clear();
                 this.coverageStatus.hide();
             }
         }));
-        context.subscriptions.push(vscode.commands.registerCommand('hack.toggleCoverageHighlight', () => { this.toggle(); }));
+        context.subscriptions.push(vscode.commands.registerCommand('hack.toggleCoverageHighlight', async () => this.toggle()));
         context.subscriptions.push(this.hhvmCoverDiag, this.coverageStatus);
 
         // Check the active file, if any
         if (vscode.window.activeTextEditor) {
-            this.check(vscode.window.activeTextEditor.document);
+            await this.check(vscode.window.activeTextEditor.document);
         }
     }
 
@@ -59,15 +59,16 @@ export class HackCoverageChecker {
             this.hhvmCoverDiag.clear();
             this.visible = false;
         } else {
+            this.visible = true;
             const editor = vscode.window.activeTextEditor;
             if (editor) {
-                this.check(editor.document);
+                await this.check(editor.document);
             }
-            this.visible = true;
         }
     }
 
     private async check(document: vscode.TextDocument) {
+        this.hhvmCoverDiag.clear();
         if (document.languageId !== 'hack' || document.uri.scheme !== 'file') {
             this.coverageStatus.hide();
             return;
@@ -75,7 +76,7 @@ export class HackCoverageChecker {
 
         let coverageResponse: CoverageResponse;
         try {
-            coverageResponse = <CoverageResponse>await this.languageClient.sendRequest(
+            coverageResponse = await this.languageClient.sendRequest(
                 'textDocument/typeCoverage',
                 { textDocument: this.languageClient.code2ProtocolConverter.asTextDocumentIdentifier(document) }
             );
@@ -92,7 +93,7 @@ export class HackCoverageChecker {
         if (this.visible && coverageResponse.uncoveredRanges) {
             const diagnostics: vscode.Diagnostic[] = [];
             coverageResponse.uncoveredRanges.forEach(uncoveredRange => {
-                const diagnostic = new vscode.Diagnostic(uncoveredRange.range, uncoveredRange.message, vscode.DiagnosticSeverity.Information);
+                const diagnostic = new vscode.Diagnostic(uncoveredRange.range, uncoveredRange.message || coverageResponse.defaultMessage, vscode.DiagnosticSeverity.Information);
                 diagnostic.source = 'Type Coverage';
                 diagnostics.push(diagnostic);
             });

--- a/src/coveragechecker.ts
+++ b/src/coveragechecker.ts
@@ -68,7 +68,7 @@ export class HackCoverageChecker {
     }
 
     private async check(document: vscode.TextDocument) {
-        if (document.languageId !== 'hack' && document.uri.scheme !== 'file') {
+        if (document.languageId !== 'hack' || document.uri.scheme !== 'file') {
             this.coverageStatus.hide();
             return;
         }


### PR DESCRIPTION
Was mistakenly sending over the coverage check request to Hack LSP for all file types, which resulted in errors.