### PR TITLE
RFC - A test folder that provides a way to submit bugs for syntax highlighting

### DIFF
--- a/syntaxes/test/.hhconfig
+++ b/syntaxes/test/.hhconfig
@@ -1,0 +1,3 @@
+# namespace aliasing
+auto_namespace_map = {"Dict": "HH\\Lib\\Dict", "Vec": "HH\\Lib\\Vec", "Keyset": "HH\\Lib\\Keyset", "C": "HH\\Lib\\C", "Str": "HH\\Lib\\Str", "PHP": "HH\\Lib\\PHP", "Math": "HH\\Lib\\Math", "PseudoRandom": "HH\\Lib\\PseudoRandom", "SecureRandom": "HH\\Lib\\SecureRandom", "Rx": "HH\\Rx", "Regex": "HH\\Lib\\Regex"}
+

--- a/syntaxes/test/README.md
+++ b/syntaxes/test/README.md
@@ -1,0 +1,7 @@
+# Syntax coloring test
+
+This folder contains interesting examples of hack code that can be used to demonstrate various syntax highlighting issues.
+
+To report a bug for syntax highlighting, please submit a file that demonstrates a snippet of code that is colored incorrectly.
+
+To test updates to syntax coloring, open this folder and verify the examples.

--- a/syntaxes/test/test1.hack
+++ b/syntaxes/test/test1.hack
@@ -1,0 +1,8 @@
+// This file has an error (unpaired quote).  Everything after line 6
+// should be colored as part of the string.
+
+<<__EntryPoint>>
+function foo(): void {
+  $x = 'SELECT (')');
+  echo $x;
+}

--- a/syntaxes/test/test2.hack
+++ b/syntaxes/test/test2.hack
@@ -1,0 +1,15 @@
+// This function should correctly highlight elements after the "shape(...)" syntax
+
+function trace_shape_scalars_as_span_tags(SpanRef $span, shape(...) $shape, vec(arraykey) $v) {
+    foreach (Shapes::toDict($shape) as $key => $value) {
+        if ($value is int) {
+            t($span, $key_prefix.(string)$key, $value);
+        } else if ($value is float) {
+            t($span, $key_prefix.(string)$key, $value);
+        } else if ($value is bool) {
+            t($span, $key_prefix.(string)$key, $value);
+        } else if ($value is string) {
+            t($span, $key_prefix.(string)$key, $value);
+        }
+    }
+}

--- a/syntaxes/test/test3.hack
+++ b/syntaxes/test/test3.hack
@@ -1,0 +1,8 @@
+// In this test, there are two >> symbols next to each other.
+// They should not break the overall flow of syntax coloring.
+// Everything after shape(...)>> should be colored correctly.
+
+protected static function initializeCoValidators(
+): vec<LoggerCoValidator<shape(...)>> {
+    return vec[];
+}


### PR DESCRIPTION
This pull request includes a test folder which allows users to upload sample files to observe quirks of syntax highlighting. 

An example is issue https://github.com/slackhq/vscode-hack/issues/70 - I have created a file, test2.hack, that encapsulates the bug report in issue 70.  Using VS Code's IDE development features, I can use the F5-debug feature to launch a version of hack that opens this folder and then screenshot the observed changes to verify whether my edits fix the reported issue.