### PR TITLE
endCaptures in type-annotation should be a map

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -340,7 +340,9 @@
           "begin": "(shape\\()",
           "end": "((,|\\.\\.\\.)?\\s*\\))",
           "endCaptures": {
-            "1": "keyword.operator.key.php"
+            "1": {
+              "name": "keyword.operator.key.php"
+            }
           },
           "name": "storage.type.shape.php",
           "patterns": [


### PR DESCRIPTION
As detailed in https://github.com/slackhq/vscode-hack/issues/76, I'm the lead maintainer of https://github.com/github/linguist which uses this grammar for syntax highlighting of Hack files on GitHub.com.

Our grammar compiler has detected an error in your grammar that was introduced in https://github.com/slackhq/vscode-hack/pull/72:

```
'Repository[type-annotation].Patterns[3].EndCaptures[1]' expected a map, got 'string'
```

The error is because the first, and only, `endCaptures` in the fourth pattern of `type-annotation` is a string:

```json
          "endCaptures": {
            "1": "keyword.operator.key.php"
          },
```

It should be a map, ie:

```json
          "endCaptures": {
            "1": {
              "name": "keyword.operator.key.php"
            }
          },
```

This PR corrects this.

Fixes https://github.com/slackhq/vscode-hack/issues/76