### PR TITLE
Use newer max unicode of 0x10ffff

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -907,7 +907,7 @@
               "include": "#namespace"
             },
             {
-              "match": "(?xi)\n([a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)                 # Exception class\n((?:\\s*\\|\\s*[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)*) # Optional additional exception classes\n\\s*\n((\\$+)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*)           # Variable",
+              "match": "(?xi)\n([a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)                 # Exception class\n((?:\\s*\\|\\s*[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)*) # Optional additional exception classes\n\\s*\n((\\$+)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*)           # Variable",
               "captures": {
                 "1": {
                   "name": "support.class.exception.php"
@@ -915,7 +915,7 @@
                 "2": {
                   "patterns": [
                     {
-                      "match": "(?i)[a-z_\\x{7f}-\\x{7fffffff}][a-z0-9_\\x{7f}-\\x{7fffffff}]*",
+                      "match": "(?i)[a-z_\\x{7f}-\\x{10ffff}][a-z0-9_\\x{7f}-\\x{10ffff}]*",
                       "name": "support.class.exception.php"
                     },
                     {


### PR DESCRIPTION
As detailed in https://github.com/slackhq/vscode-hack/issues/78, https://github.com/slackhq/vscode-hack/pull/72 introduced another error picked up by our grammar compiler. This time it's an invalid unicode regex match:

```
Invalid regex in grammar: `source.hack` (in `syntaxes/hack.json`) contains a malformed regex (regex "`(?xi)([a-z_\x{7f}-\x{7fffffff}]`...": character value in \x{} or \o{} is too large (at offset 30))
```

... and ...

```
Invalid regex in grammar: `source.hack` (in `syntaxes/hack.json`) contains a malformed regex (regex "`(?i)[a-z_\x{7f}-\x{7fffffff}][a-`...": character value in \x{} or \o{} is too large (at offset 27))
```

The line numbers have been truncated. but they correspond to...

https://github.com/slackhq/vscode-hack/blob/62329f6b026a75f805daf701071df45ba09330a5/syntaxes/hack.json#L910

... and ...

https://github.com/slackhq/vscode-hack/blob/62329f6b026a75f805daf701071df45ba09330a5/syntaxes/hack.json#L918

... respectively.

I suspect the intent here was to cover all unicode chars from `0x7F` to the end, however `0x7FFFFFFF` is no longer a valid UTF-8 unicode char. As of 2003, the max is `0x10FFFF`.

From https://en.wikipedia.org/wiki/UTF-8#History:

> In November 2003, UTF-8 was restricted by RFC 3629 to match the constraints of the UTF-16 character encoding: explicitly prohibiting code points corresponding to the high and low surrogate characters removed more than 3% of the three-byte sequences, and ending at U+10FFFF removed more than 48% of the four-byte sequences and all five- and six-byte sequences. 

This PR addresses this by switching out `\x{7fffffff}` with `\x{10ffff}`.

Fixes https://github.com/slackhq/vscode-hack/issues/78