### PR TITLE
Launch scripts in Docker container when connected

### DIFF
--- a/package.json
+++ b/package.json
@@ -297,7 +297,8 @@
     ]
   },
   "activationEvents": [
-    "workspaceContains:.hhconfig"
+    "workspaceContains:.hhconfig",
+    "onDebug"
   ],
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/HhvmDebugConfigurationProvider.ts
+++ b/src/HhvmDebugConfigurationProvider.ts
@@ -3,7 +3,7 @@ import { WorkspaceFolder, DebugConfigurationProvider, DebugConfiguration, Cancel
 
 export class HhvmDebugConfigurationProvider implements DebugConfigurationProvider {
 
-    resolveDebugConfiguration(folder: WorkspaceFolder | undefined, debugConfig: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration> {
+    resolveDebugConfiguration(folder: WorkspaceFolder | undefined, debugConfig: DebugConfiguration, _token?: CancellationToken): ProviderResult<DebugConfiguration> {
 
         // if launch.json is missing or empty
         if (!debugConfig.type || !debugConfig.request || !debugConfig.name || !folder) {
@@ -20,10 +20,6 @@ export class HhvmDebugConfigurationProvider implements DebugConfigurationProvide
             debugConfig.remoteType = config.remoteType;
             debugConfig.remoteWorkspacePath = config.remoteWorkspacePath;
             debugConfig.dockerContainerName = config.dockerContainerName;
-
-            //if (debugConfig.remoteEnabled && debugConfig.remoteType === "docker") {
-            debugConfig.socket = '/tmp/vsdebug.sock';
-            //}
         }
 
         return debugConfig;

--- a/src/HhvmDebugConfigurationProvider.ts
+++ b/src/HhvmDebugConfigurationProvider.ts
@@ -1,0 +1,31 @@
+import * as config from "./Config";
+import { WorkspaceFolder, DebugConfigurationProvider, DebugConfiguration, CancellationToken, ProviderResult } from 'vscode';
+
+export class HhvmDebugConfigurationProvider implements DebugConfigurationProvider {
+
+    resolveDebugConfiguration(folder: WorkspaceFolder | undefined, debugConfig: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration> {
+
+        // if launch.json is missing or empty
+        if (!debugConfig.type || !debugConfig.request || !debugConfig.name || !folder) {
+            return undefined;
+        }
+
+        if (debugConfig.type === "hhvm" && debugConfig.request === "launch") {
+            if (!debugConfig.script) {
+                debugConfig.script = "${file}";
+            }
+
+            debugConfig.localWorkspaceRoot = folder.uri.fsPath;
+            debugConfig.remoteEnabled = config.remoteEnabled;
+            debugConfig.remoteType = config.remoteType;
+            debugConfig.remoteWorkspacePath = config.remoteWorkspacePath;
+            debugConfig.dockerContainerName = config.dockerContainerName;
+
+            //if (debugConfig.remoteEnabled && debugConfig.remoteType === "docker") {
+            debugConfig.socket = '/tmp/vsdebug.sock';
+            //}
+        }
+
+        return debugConfig;
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { LegacyHackTypeChecker } from './LegacyHackTypeChecker';
 import { LSPHackTypeChecker } from './LSPHackTypeChecker';
 import { LSPHHASTLint } from './LSPHHASTLint';
 import * as hh_client from './proxy';
+import { HhvmDebugConfigurationProvider } from './HhvmDebugConfigurationProvider';
 
 export async function activate(context: vscode.ExtensionContext) {
 
@@ -28,6 +29,8 @@ export async function activate(context: vscode.ExtensionContext) {
     } else {
         services.push((new LegacyHackTypeChecker(context)).run());
     }
+
+    vscode.debug.registerDebugConfigurationProvider("hhvm", new HhvmDebugConfigurationProvider());
 
     await Promise.all(services);
 }


### PR DESCRIPTION
If the current IDE session is connected to a remote typechecker of type "docker", all scripts run via the HHVM launch debug target will now run inside the Docker container instead of the host machine. Setting breakpoints in this mode isn't yet supported, and will be added soon.