### PR TITLE
[Syntax Highlighting] Support `implements` on traits

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -171,6 +171,55 @@
         }
       ]
     },
+    "implements": {
+      "patterns": [
+        {
+	  "begin": "(?i)(implements)\\s+",
+	  "beginCaptures": {
+	    "1": {
+	      "name": "storage.modifier.implements.php"
+	    }
+	  },
+	  "end": "(?i)(?=[;{])",
+	  "patterns": [
+	    {
+	      "include": "#comments"
+	    },
+	    {
+	      "begin": "(?i)(?=[a-z0-9_\\\\]+)",
+	      "contentName": "meta.other.inherited-class.php",
+	      "end": "(?i)(?:\\s*(?:,|(?=[^a-z0-9_\\\\\\s]))\\s*)",
+	      "patterns": [
+		{
+		  "begin": "(?i)(?=\\\\?[a-z_0-9]+\\\\)",
+		  "end": "(?i)([a-z_][a-z_0-9]*)?(?=[^a-z0-9_\\\\])",
+		  "endCaptures": {
+		    "1": {
+		      "name": "entity.other.inherited-class.php"
+		    }
+		  },
+		  "patterns": [
+		    {
+		      "include": "#namespace"
+		    }
+		  ]
+		},
+		{
+		  "include": "#class-builtin"
+		},
+		{
+		  "include": "#namespace"
+		},
+		{
+		  "match": "(?i)[a-z_][a-z_0-9]*",
+		  "name": "entity.other.inherited-class.php"
+		}
+	      ]
+	    }
+	  ]
+	}
+      ]
+    },
     "attributes": {
       "patterns": [
         {
@@ -693,6 +742,9 @@
             },
             {
               "include": "#generics"
+            },
+            {
+              "include": "#implements"
             }
           ]
         },
@@ -782,6 +834,9 @@
               "include": "#generics"
             },
             {
+              "include": "#implements"
+            },
+            {
               "begin": "(?i)(extends)\\s+",
               "beginCaptures": {
                 "1": {
@@ -814,51 +869,6 @@
                 {
                   "match": "(?i)[a-z_][a-z_0-9]*",
                   "name": "entity.other.inherited-class.php"
-                }
-              ]
-            },
-            {
-              "begin": "(?i)(implements)\\s+",
-              "beginCaptures": {
-                "1": {
-                  "name": "storage.modifier.implements.php"
-                }
-              },
-              "end": "(?i)(?=[;{])",
-              "patterns": [
-                {
-                  "include": "#comments"
-                },
-                {
-                  "begin": "(?i)(?=[a-z0-9_\\\\]+)",
-                  "contentName": "meta.other.inherited-class.php",
-                  "end": "(?i)(?:\\s*(?:,|(?=[^a-z0-9_\\\\\\s]))\\s*)",
-                  "patterns": [
-                    {
-                      "begin": "(?i)(?=\\\\?[a-z_0-9]+\\\\)",
-                      "end": "(?i)([a-z_][a-z_0-9]*)?(?=[^a-z0-9_\\\\])",
-                      "endCaptures": {
-                        "1": {
-                          "name": "entity.other.inherited-class.php"
-                        }
-                      },
-                      "patterns": [
-                        {
-                          "include": "#namespace"
-                        }
-                      ]
-                    },
-                    {
-                      "include": "#class-builtin"
-                    },
-                    {
-                      "include": "#namespace"
-                    },
-                    {
-                      "match": "(?i)[a-z_][a-z_0-9]*",
-                      "name": "entity.other.inherited-class.php"
-                    }
-                  ]
                 }
               ]
             }


### PR DESCRIPTION
Traits can implement interfaces like classes. This adds syntax highlighting to support the same configuration for `implements` on Hack traits as `implements` on Hack classes

Tested by copying syntaxes/hack.json to my local config for VS code and inspecting the results. Here are some screenshots: 
Before:
<img width="437" alt="Screen Shot 2019-11-12 at 7 04 56 AM" src="https://user-images.githubusercontent.com/3335620/68689062-ac8b6700-0524-11ea-8e11-55ff17da291a.png">


After:
![Screen Shot 2019-11-12 at 8 15 35 AM](https://user-images.githubusercontent.com/3335620/68689102-b90fbf80-0524-11ea-9d9d-1bf376a4d4aa.png)




