### PR TITLE
Add option to invoke URL after debugger is attached

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,10 @@
                 "type": "string",
                 "description": "Absolute path to local workspace root, to map to remote server",
                 "default": "${workspaceFolder}"
+              },
+              "launchUrl": {
+                "type": "string",
+                "description": "Make an HTTP GET request to this URL once the debugger is attached, and automatically detach when the request is complete"
               }
             }
           },


### PR DESCRIPTION
The "attach" debugger target currently attaches to a running web server, but you have to invoke any web requests to test it yourself. This PR adds an option to specify a `launchUrl` that will get invoked whenever the debugger is attached. The response will get piped to the Debug Output tab in VS Code, and the debugger will automatically detach when the web request is finished.

All the supported VS Code variable substitutions can be used in this config.