### PR TITLE
Fix string interpolation syntax highlighting

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -591,38 +591,29 @@
       "comment": "http://www.php.net/manual/en/language.types.string.php#language.types.string.parsing",
       "patterns": [
         {
+          "comment": "Interpolating octal values e.g. \\01 or \\07.",
           "match": "\\\\[0-7]{1,3}",
           "name": "constant.numeric.octal.php"
         },
         {
+          "comment": "Interpolating hex values e.g. \\x1 or \\xFF.",
           "match": "\\\\x[0-9A-Fa-f]{1,2}",
           "name": "constant.numeric.hex.php"
         },
         {
+          "comment": "Escaped characters in double-quoted strings e.g. \\n or \\t.",
           "match": "\\\\[nrt\\\\\\$\\\"]",
           "name": "constant.character.escape.php"
         },
         {
-          "begin": "(\\{)(?=\\$.*?\\})",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.definition.variable.php"
-            }
-          },
-          "end": "(\\})",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.definition.variable.php"
-            }
-          },
-          "patterns": [
-            {
-              "include": "#language"
-            }
-          ]
+          "comment": "Interpolating expressions in double-quoted strings with {} e.g. {$x->y->z[0][1]}.",
+          "match": "(\\{\\$.*?\\})",
+          "name": "variable.other.php"
         },
         {
-          "include": "#variable-name"
+          "comment": "Interpolating simple variables, e.g. $x, $x->y, $x[z] but not $x->y->z.",
+          "match": "(\\$[a-zA-Z_][a-zA-Z0-9_]*((->[a-zA-Z_][a-zA-Z0-9_]*)|(\\[[a-zA-Z0-9_]+\\]))?)",
+          "name": "variable.other.php"
         }
       ]
     },

--- a/syntaxes/test/interpolation.hack
+++ b/syntaxes/test/interpolation.hack
@@ -1,0 +1,33 @@
+// See https://www.php.net/manual/en/language.types.string.php#language.types.string.parsing
+function double_quoted(): void {
+  // Escape characters.
+  $x = "world \n \t \\";
+
+  // Octal/hex.
+  $x = "world \07 \xFF"
+
+  // Simple interpolation.
+  $y = "hello $x";
+
+  // We can do a single array access, but not nested.
+  $y = "hello $x[0]";
+  $y = "hello $x[0][1]"; // literal "[1]"
+
+  // Similarly with properties, we can only access the first.
+  $y = "hello $x->foo";
+  $y = "hello $x->foo->bar"; // literal "->bar"
+
+  // In {} we can use more complex expressions.
+  $y = "hello {$x->y->z[0][1] + 2}";
+
+  // Just accessing $x here due to the space.
+  $y = "hello { $x + 1}";
+}
+
+function single_quoted(): void {
+  // This is a literal \ and n.
+  $x = 'foo\n bar';
+
+  // No interpolation here.
+  $x = 'foo $x';
+}


### PR DESCRIPTION
Previously, we'd highlight `"{$x->y->z}"` incorrectly, and `"$x[foo]"`
would look like it wasn't accessing the key in $x.

Highlight the whole interpolation to make this more explicit.

Screenshot of the new highlighting:

![Screenshot 2020-01-27 at 18 54 16](https://user-images.githubusercontent.com/70800/73204191-711d3380-4136-11ea-9206-142d73060776.png)