### PR TITLE
Update snippets

### DIFF
--- a/snippets/hack.json
+++ b/snippets/hack.json
@@ -1,20 +1,12 @@
 {
   ".source.hack": {
-    "$GLOBALS['…']": {
-      "prefix": "globals",
-      "body": "$GLOBALS['${1:variable}']${2: = }${3:something}${4:;}$0"
-    },
     "function __construct": {
       "prefix": "con",
-      "body": "function __construct(${1:$${2:foo} ${3:= ${4:null}}}) {\n\t${2:$this->$0 = $$0;}$0\n}"
-    },
-    "Heredoc": {
-      "prefix": "<<<",
-      "body": "<<<${1:HTML}\n${2:content here}\n$1;\n"
+      "body": "${1:public} function __construct($2) {\n\t${3:# code...;}$0\n}"
     },
     "Class Variable": {
       "prefix": "doc_v",
-      "body": "/**\n * ${3:undocumented class variable}\n *\n * @var ${4:string}\n **/\n${1:var} $$2;$0"
+      "body": "/**\n * ${4:undocumented class variable}\n */\n${1:private} ${2:type} $${3:name};$0"
     },
     "Start Docblock": {
       "prefix": "/**",
@@ -22,27 +14,19 @@
     },
     "class …": {
       "prefix": "class",
-      "body": "/**\n * $1\n */\nclass ${2:ClassName} ${3:extends ${4:AnotherClass}}\n{\n\t$5\n\tfunction ${6:__construct}(${7:argument})\n\t{\n\t\t${0:# code...}\n\t}\n}\n"
+      "body": "/**\n * $1\n */\nclass ${2:ClassName} ${3:extends ${4:AnotherClass}} {\n\t${5:public} function ${6:__construct}($7) {\n\t\t${0:# code...}\n\t}\n}\n"
     },
     "trait …": {
       "prefix": "trait",
-      "body": "/**\n * $1\n */\ntrait ${2:TraitName}\n{\n\tfunction ${3:functionName}(${4:argument})\n\t{\n\t\t${5:# code...}\n\t}\n}\n"
+      "body": "/**\n * $1\n */\ntrait ${2:TraitName} {\n\tfunction ${3:functionName}($4): $5 {\n\t\t${6:# code...}\n\t}\n}\n"
     },
     "const _ _ = _": {
       "prefix": "const",
       "body": "const ${1:type} ${2:name} = ${3:value};\n$0"
     },
-    "define(…, …) >> Prefer const": {
-      "prefix": "def",
-      "body": "define('$1', ${2:'$3'});\n$0"
-    },
-    "defined(…)": {
-      "prefix": "def?",
-      "body": "$1defined('$2')$0"
-    },
     "do … while …": {
       "prefix": "do",
-      "body": "do {\n\t${0:# code...}\n} while (${1:$a <= 10});"
+      "body": "do {\n\t${0:# code...}\n} while (${1:\\$a <= 10});"
     },
     "echo \"…\"": {
       "prefix": "echo",
@@ -58,7 +42,7 @@
     },
     "for …": {
       "prefix": "for",
-      "body": "for ($${1:i}=${2:0}; $${1:i} < $3; $${1:i}++) { \n\t${0:# code...}\n}"
+      "body": "for ($${1:i} = ${2:0}; $${1:i} < $3; $${1:i}++) { \n\t${0:# code...}\n}"
     },
     "foreach …": {
       "prefix": "foreach",
@@ -66,7 +50,7 @@
     },
     "function …": {
       "prefix": "func",
-      "body": "${1:public }function ${2:FunctionName}(${3:$${4:value}${5:=''}})\n{\n\t${0:# code...}\n}"
+      "body": "${1:public }function ${2:functionName}(${3:$${4:value}${5:=''}})\n{\n\t${0:# code...}\n}"
     },
     "if … else …": {
       "prefix": "ifelse",
@@ -78,15 +62,7 @@
     },
     "$… = ( … ) ? … : …": {
       "prefix": "if?",
-      "body": "$${1:retVal} = (${2:condition}) ? ${3:a} : ${4:b} ;"
-    },
-    "$… = array (…)": {
-      "prefix": "array",
-      "body": "$${1:arrayName} = array('$2' => $3${4:,} $0);"
-    },
-    "$… = […]": {
-      "prefix": "shorray",
-      "body": "$${1:arrayName} = ['$2' => $3${4:,} $0];"
+      "body": "$${1:retVal} = (${2:condition}) ? ${3:\\$a} : ${4:\\$b} ;"
     },
     "… => …": {
       "prefix": "keyval",
@@ -94,11 +70,11 @@
     },
     "require_once …": {
       "prefix": "req1",
-      "body": "require_once '${1:file}';$0"
+      "body": "require_once '${1:file}';\n$0"
     },
     "return": {
       "prefix": "ret",
-      "body": "return$1;$0"
+      "body": "return $1;$0"
     },
     "return false": {
       "prefix": "ret0",
@@ -118,11 +94,11 @@
     },
     "$this->…": {
       "prefix": "this",
-      "body": "$this->$0"
+      "body": "\\$this->$0"
     },
     "echo $this->…": {
       "prefix": "ethis",
-      "body": "echo $this->$0"
+      "body": "echo \\$this->$1;\n$0"
     },
     "Throw Exception": {
       "prefix": "throw",
@@ -130,7 +106,7 @@
     },
     "while …": {
       "prefix": "while",
-      "body": "while (${1:$a <= 10}) {\n\t${0:# code...}\n}"
+      "body": "while (${1:$$a <= 10}) {\n\t${0:# code...}\n}"
     }
   }
 }


### PR DESCRIPTION
I am not a snippets kinda guy, but when I use the built-in ones, I am not quite pleased.

### Remove things we should discourage
 - globals
 - defining constants with define()
 - declaring array literals using `[]` (removed in new hhvm versions)
 - declaring array literals using array() (pending removal)

### De PHPify
 - Class variables with `var`
 - methods / functions without types
 - methods without accessibility modifiers

### Things that won't work
 - Heredoc (since the closing `HTML` is not in the left margin, this is a parse error)

### Formatting
 - Drop PSR-2 support and using hackfmt compatible whitespace

### Misc
 - Escaping dollar signs, where this was the intent