### PR TITLE
Support Hack root in an arbitrary subdirectory

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,6 +196,11 @@
           "default": "hh_client",
           "description": "Absolute path to the hh_client executable. This can be left empty if hh_client is already in your environment $PATH."
         },
+        "hack.rootPath": {
+          "type": "string",
+          "default": "",
+          "description": "Relative path to the directory containing .hhconfig"
+        },
         "hack.workspaceRootPath": {
           "type": "string",
           "default": null,
@@ -311,7 +316,7 @@
     ]
   },
   "activationEvents": [
-    "workspaceContains:.hhconfig",
+    "workspaceContains:**/.hhconfig",
     "onDebug"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -196,10 +196,10 @@
           "default": "hh_client",
           "description": "Absolute path to the hh_client executable. This can be left empty if hh_client is already in your environment $PATH."
         },
-        "hack.rootPath": {
+        "hack.hhconfigPath": {
           "type": "string",
-          "default": "",
-          "description": "Relative path to the directory containing .hhconfig"
+          "default": ".hhconfig",
+          "description": "Workspace-relative path to .hhconfig file, the containing directory becomes the Hack Langauge Server root"
         },
         "hack.workspaceRootPath": {
           "type": "string",

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -10,6 +10,7 @@ const hackConfig = vscode.workspace.getConfiguration("hack");
 // tslint:disable-next-line:no-non-null-assertion
 export const localWorkspacePath = vscode.workspace.workspaceFolders![0].uri
   .fsPath;
+export const workspaceRelativeRootPath = hackConfig.get<string>("rootPath") || "";
 
 export let clientPath = hackConfig.get<string>("clientPath") || "hh_client";
 clientPath = clientPath.replace("${workspaceFolder}", localWorkspacePath);

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -10,7 +10,7 @@ const hackConfig = vscode.workspace.getConfiguration("hack");
 // tslint:disable-next-line:no-non-null-assertion
 export const localWorkspacePath = vscode.workspace.workspaceFolders![0].uri
   .fsPath;
-export const workspaceRelativeRootPath = hackConfig.get<string>("rootPath") || "";
+export const hhconfigPath = hackConfig.get<string>("hhconfigPath") || ".hhconfig";
 
 export let clientPath = hackConfig.get<string>("clientPath") || "hh_client";
 clientPath = clientPath.replace("${workspaceFolder}", localWorkspacePath);

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -12,12 +12,11 @@ import * as config from "./Config";
  * @param includeScheme Whether to include the file:// scheme in the response or not
  */
 export const mapFromWorkspaceUri = (file: vscode.Uri): string => {
-  if (!config.remoteEnabled || !config.remoteWorkspacePath) {
-    return file.toString();
+  let workspaceRoot = file.toString()
+  if (config.remoteEnabled && config.remoteWorkspacePath) {
+    workspaceRoot = workspaceRoot.replace(config.localWorkspacePath, config.remoteWorkspacePath);
   }
-  return file
-    .toString()
-    .replace(config.localWorkspacePath, config.remoteWorkspacePath);
+  return workspaceRoot + "/" + config.workspaceRelativeRootPath;
 };
 
 /**

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -16,7 +16,8 @@ export const mapFromWorkspaceUri = (file: vscode.Uri): string => {
   if (config.remoteEnabled && config.remoteWorkspacePath) {
     workspaceRoot = workspaceRoot.replace(config.localWorkspacePath, config.remoteWorkspacePath);
   }
-  return workspaceRoot + "/" + config.workspaceRelativeRootPath;
+  const workspaceRelativeRoot = config.hhconfigPath.replace(/\.hhconfig$/, "")
+  return workspaceRoot + "/" + workspaceRelativeRoot.replace(".hhconfig", "");
 };
 
 /**


### PR DESCRIPTION
Closes: #94 

This didn't end up being as easy as I hypothesized in the issue, but this seems like the best way to support a non-workspace root for Hack code.