### PR TITLE
Improve highlighting of namespaces and collection literals

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -736,7 +736,7 @@
           ]
         },
         {
-          "begin": "(?i)(?:^\\s*|\\s*)(namespace)\\b\\s+(?=([a-z0-9_\\\\]+\\s*($|[;{]|(\\/[\\/*])))|$)",
+          "begin": "(?i)(?:^\\s*|\\s*)(namespace)\\b\\s+(?=([a-z0-9_\\\\]*\\s*($|[;{]|(\\/[\\/*])))|$)",
           "beginCaptures": {
             "1": {
               "name": "keyword.other.namespace.php"

--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -459,7 +459,7 @@
     "literal-collections": {
       "patterns": [
         {
-          "begin": "([A-Za-z_0-9]+)\\s*({)",
+          "begin": "(Vector|ImmVector|Set|ImmSet|Map|ImmMap)\\s*({)",
           "end": "(})",
           "beginCaptures": {
             "1": {

--- a/syntaxes/test/collections.hack
+++ b/syntaxes/test/collections.hack
@@ -1,0 +1,11 @@
+
+function create_collections(): void {
+  $v = Vector {};
+  $v2 = ImmVector {};
+
+  $m = Map { 'x' => 1 };
+  $m2 = ImmMap { 'x' => 1 };
+
+  $m = Set {};
+  $m2 = ImmSet {};
+}

--- a/syntaxes/test/namespaces.hack
+++ b/syntaxes/test/namespaces.hack
@@ -1,0 +1,7 @@
+namespace foo {
+  function one(): void {}
+}
+
+namespace {
+  function two(): void {}
+}


### PR DESCRIPTION
Only Vector, Set and Map (plus their immutable versions) can be used as collection literals. Make the regular expression more precise. This helps users spot mistakes, and avoids bad highlighting of other code using curly braces.

![Screenshot 2020-08-13 at 17 55 52](https://user-images.githubusercontent.com/70800/90201220-10321180-dd8f-11ea-9f36-33aac294f462.png)

Anonymous namespaces were previously highlighted as collection literals. Ensure they are highlighted the same was as named namespaces.

![Screenshot 2020-08-13 at 17 58 00](https://user-images.githubusercontent.com/70800/90201258-322b9400-dd8f-11ea-92ad-2555e12aae9e.png)