### PR TITLE
Remove syntax highlighting for backtick strings

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -1288,9 +1288,6 @@
           "match": "(?i)^\\s*([a-z_][a-z_0-9]*)\\s*:"
         },
         {
-          "include": "#string-backtick"
-        },
-        {
           "begin": "\\[",
           "beginCaptures": {
             "0": {
@@ -1417,9 +1414,6 @@
         },
         {
           "include": "#numbers"
-        },
-        {
-          "include": "#string-backtick"
         },
         {
           "include": "#variables"
@@ -1762,30 +1756,6 @@
         },
         {
           "include": "source.sql"
-        }
-      ]
-    },
-    "string-backtick": {
-      "begin": "`",
-      "beginCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.begin.php"
-        }
-      },
-      "end": "`",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.end.php"
-        }
-      },
-      "name": "string.interpolated.php",
-      "patterns": [
-        {
-          "match": "\\\\.",
-          "name": "constant.character.escape.php"
-        },
-        {
-          "include": "#interpolation"
         }
       ]
     },


### PR DESCRIPTION
Backticks are no longer legal Hack.

![Screenshot 2020-08-13 at 18 07 54](https://user-images.githubusercontent.com/70800/90201532-fe04a300-dd8f-11ea-873a-b822246a85e7.png)

I haven't added a test file, as it seems silly to have nonexistent syntax examples in the repo. Happy to add one if you prefer.