### PR TITLE
Highlight Pair { ... } consistently with Vector {}

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -459,7 +459,7 @@
     "literal-collections": {
       "patterns": [
         {
-          "begin": "(Vector|ImmVector|Set|ImmSet|Map|ImmMap)\\s*({)",
+          "begin": "(Vector|ImmVector|Set|ImmSet|Map|ImmMap|Pair)\\s*({)",
           "end": "(})",
           "beginCaptures": {
             "1": {

--- a/syntaxes/test/collections.hack
+++ b/syntaxes/test/collections.hack
@@ -8,4 +8,6 @@ function create_collections(): void {
 
   $m = Set {};
   $m2 = ImmSet {};
+
+  $p = Pair { 1, 2 };
 }


### PR DESCRIPTION
`Pair` was missing in #102. Fix that, and add it to the sample file.