### PR TITLE
Start hh_client in non-lsp mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,10 @@ export async function activate(context: vscode.ExtensionContext) {
     return;
   }
 
+  console.log("Starting hh_client...");
+  await hh_client.start();
+  console.log("Done starting hh_client.");
+
   const services: Promise<void>[] = [];
   services.push(LSPHHASTLint.START_IF_CONFIGURED_AND_ENABLED(context));
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,6 +11,13 @@ export async function version(): Promise<hack.Version | undefined> {
   return run(["--version"]);
 }
 
+/**
+ * Hack client hangs if executed in lsp mode before running it standalone.
+ */
+export async function start(): Promise<hack.Version | undefined> {
+  return run([]);
+}
+
 export async function check(): Promise<hack.CheckResponse> {
   return run(["check"]);
 }


### PR DESCRIPTION
There's [some](https://github.com/facebook/hhvm/issues/8322) scenarios [where](https://github.com/facebook/hhvm/issues/8548) `hh_client` will hang on macOS. One of those cases is if we start the client in lsp mode without first starting `hh_client`. 

This change is a workaround that runs `hh_client` when the vscode-hack extension starts up before `hh_client lsp` is called. 

It's still possible for `hh_client` to hang in other ways (I haven't been able to consistently recreate this) but this change works around at least one known scenario.

![hh_client-before-hh_client-lsp](https://user-images.githubusercontent.com/1281153/91016022-f7043e80-e5a0-11ea-8a6a-ccdff99435cd.gif)
