### PR TITLE
Highlight all built-in types consistently

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -158,7 +158,7 @@
             },
             {
               "match": "([-+])?([A-Za-z_][A-Za-z0-9_]*)(?:\\s+(as|super)\\s+([A-Za-z_][A-Za-z0-9_]*))?",
-              "name": "storage.type.php"
+              "name": "support.type.php"
             },
             {
               "include": "#type-annotation"
@@ -357,15 +357,15 @@
       ]
     },
     "type-annotation": {
-      "name": "storage.type.php",
+      "name": "support.type.php",
       "patterns": [
         {
           "match": "\\barray\\b",
-          "name": "storage.type.array.php"
+          "name": "support.type.array.php"
         },
         {
           "match": "\\b(?:bool|int|float|string|array|resource|mixed|arraykey|nonnull|dict|vec|keyset)\\b",
-          "name": "storage.type.php"
+          "name": "support.type.php"
         },
         {
           "begin": "([A-Za-z_][A-Za-z0-9_]*)<",
@@ -573,7 +573,7 @@
       "patterns": [
         {
           "match": "(parent|static|self)(?=[^a-z0-9_])",
-          "name": "storage.type.php"
+          "name": "support.type.php"
         },
         {
           "include": "#class-name"
@@ -1096,7 +1096,7 @@
           "patterns": [
             {
               "match": "(self|static|parent)\\b",
-              "name": "storage.type.php"
+              "name": "support.type.php"
             },
             {
               "include": "#class-name"
@@ -1153,14 +1153,14 @@
         {
           "captures": {
             "1": {
-              "name": "storage.type.php"
+              "name": "support.type.php"
             }
           },
           "match": "(?i)\\s*\\(\\s*(array|real|double|float|int(eger)?|bool(ean)?|string|object|binary|unset|arraykey|nonnull|dict|vec|keyset)\\s*\\)"
         },
         {
           "match": "(?i)\\b(array|real|double|float|int(eger)?|bool(ean)?|string|class|clone|var|function|interface|trait|parent|self|object|arraykey|nonnull|dict|vec|keyset)\\b",
-          "name": "storage.type.php"
+          "name": "support.type.php"
         },
         {
           "match": "(?i)\\b(global|abstract|const|extends|implements|final|p(r(ivate|otected)|ublic)|static)\\b",

--- a/syntaxes/test/basic_types.hack
+++ b/syntaxes/test/basic_types.hack
@@ -1,0 +1,2 @@
+// All of these type names should be highlighted the same way.
+function foo(num $x, string $s, int $s, Thing $x): void {}


### PR DESCRIPTION
Ensure that we use `support.type` for all the built-in types. This keeps highlighting consistent, and distinct from keyword highlighting.

Before:

![Screenshot 2020-09-08 at 18 34 53](https://user-images.githubusercontent.com/70800/92544235-45047d80-f202-11ea-890c-ff328464e456.png)

After:

![Screenshot 2020-09-08 at 18 34 15](https://user-images.githubusercontent.com/70800/92544247-49c93180-f202-11ea-8ca8-982023aa454c.png)
