### PR TITLE
Show inital typechecking progress in status bar

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,9 +26,12 @@ export async function activate(context: vscode.ExtensionContext) {
     return;
   }
 
-  console.log("Starting hh_client...");
-  await hh_client.start();
-  console.log("Done starting hh_client.");
+  await vscode.window.withProgress({
+    location: vscode.ProgressLocation.Window,
+    title: `Running Hack typechecker`
+  }, async () => {
+    return hh_client.start();
+  });
 
   const services: Promise<void>[] = [];
   services.push(LSPHHASTLint.START_IF_CONFIGURED_AND_ENABLED(context));


### PR DESCRIPTION
This adds to @antoniodejesusochoasolano's last change and shows the user an indication that the typechecker is currently running. Very useful for _certain_ repos that may take a while to start up.

![image](https://user-images.githubusercontent.com/341507/92846190-a8c2ae00-f39c-11ea-8c49-a9cfeffcedf5.png)
