### PR TITLE
Improve accuracy of boolean highlighting

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -284,7 +284,7 @@
           "end": "(?=[^\\\\a-zA-Z_\\x{7f}-\\x{ff}])",
           "patterns": [
             {
-              "match": "(?i)\\b(TRUE|FALSE|NULL|__(FILE|DIR|FUNCTION|CLASS|METHOD|LINE|NAMESPACE)__|ON|OFF|YES|NO|NL|BR|TAB)\\b",
+              "match": "(?i)\\b(TRUE|FALSE|NULL|__(FILE|DIR|FUNCTION|CLASS|METHOD|LINE|NAMESPACE)__)\\b",
               "name": "constant.language.php"
             },
             {
@@ -1231,7 +1231,7 @@
           "name": "keyword.operator.arithmetic.php"
         },
         {
-          "match": "(?i)(!|&&|\\|\\|)|\\b(and|or|xor)\\b",
+          "match": "(!|&&|\\|\\|)",
           "name": "keyword.operator.logical.php"
         },
         {

--- a/syntaxes/test/bools.hack
+++ b/syntaxes/test/bools.hack
@@ -1,0 +1,18 @@
+
+function booleans(): void {
+  // normal boolean literals
+  $x = true;
+  $y = false;
+
+  // booleans are case insensitive
+  $x = True;
+  $y = FALSE;
+
+  // yes/no are not booleans.
+  $x = yes;
+  $y = no;
+
+  // logical operators.
+  $x = !true;
+  $y = $x && ($x || true);
+}


### PR DESCRIPTION
`yes`, `no`, `on` and `off` are not boolean literals. `and`, `or` and
`xor` are no longer valid operators in Hack.