### PR TITLE
Correctly highlight `is`, `as` and `instanceof`

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -1235,18 +1235,7 @@
           "name": "keyword.operator.logical.php"
         },
         {
-          "match": "(?i)\\b(is|as)\\b",
-          "name": "keyword.operator.type.php"
-        },
-        {
-          "include": "#function-call"
-        },
-        {
-          "match": "<<|>>|~|\\^|&|\\|",
-          "name": "keyword.operator.bitwise.php"
-        },
-        {
-          "begin": "(?i)\\b(instanceof)\\b\\s+(?=[\\\\$a-z_])",
+          "begin": "(?i)\\b(as|is)\\b\\s+(?=[\\\\$a-z_])",
           "beginCaptures": {
             "1": {
               "name": "keyword.operator.type.php"
@@ -1261,6 +1250,17 @@
               "include": "#variable-name"
             }
           ]
+        },
+        {
+          "match": "(?i)\\b(is|as)\\b",
+          "name": "keyword.operator.type.php"
+        },
+        {
+          "include": "#function-call"
+        },
+        {
+          "match": "<<|>>|~|\\^|&|\\|",
+          "name": "keyword.operator.bitwise.php"
         },
         {
           "include": "#numbers"

--- a/syntaxes/test/basic_types.hack
+++ b/syntaxes/test/basic_types.hack
@@ -1,2 +1,6 @@
 // All of these type names should be highlighted the same way.
-function foo(num $x, string $s, int $s, Thing $x): void {}
+function foo(num $x, string $s, int $s, Thing $x): void {
+  if ($x is Foo) {
+    $x as Thing;
+  }
+}


### PR DESCRIPTION
This ensures that `is Foo` and `as Foo` correctly highlight `Foo` as a type.