### PR TITLE
Add Hack Error suppression to LSP mode

### DIFF
--- a/src/LSPHackTypeChecker.ts
+++ b/src/LSPHackTypeChecker.ts
@@ -15,6 +15,8 @@ import { HackCoverageChecker } from "./coveragechecker";
 import * as remote from "./remote";
 import * as hack from "./types/hack";
 import * as utils from "./Utils";
+import * as providers from "./providers";
+import * as suppressions from "./suppressions";
 import { ShowStatusRequest } from "./types/lsp";
 
 export class LSPHackTypeChecker {
@@ -29,6 +31,24 @@ export class LSPHackTypeChecker {
       vscode.StatusBarAlignment.Left
     );
     context.subscriptions.push(this.status);
+
+    // add command and provider to add an error suppression comment
+    context.subscriptions.push(
+      vscode.languages.registerCodeActionsProvider(
+        {
+          language: "hack",
+          scheme: "file"
+        },
+        new providers.HackCodeActionProvider()
+      )
+    );
+
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        "hack.suppressError",
+        suppressions.suppressError
+      )
+    );
   }
 
   public static IS_SUPPORTED(version: hack.Version): boolean {

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -349,7 +349,7 @@ export class HackCodeActionProvider implements vscode.CodeActionProvider {
       const commands: vscode.Command[] = [];
       for (const error of filteredErrors) {
         commands.push({
-          title: `Suppress: ${error.code}`,
+          title: `Suppress Hack Error: ${error.code}`,
           command: "hack.suppressError",
           arguments: [document, error.range.start.line, [error.code]]
         });
@@ -357,7 +357,7 @@ export class HackCodeActionProvider implements vscode.CodeActionProvider {
       if (commands.length > 1) {
         const allCodes = filteredErrors.map(f => f.code);
         commands.push({
-          title: "Suppress All",
+          title: "Suppress All Hack Errors",
           command: "hack.suppressError",
           arguments: [document, filteredErrors[0].range.start.line, allCodes]
         });


### PR DESCRIPTION
Add a code action to allow hack errors to be quickly FIXME'ed.

The code for the error suppression quickfix was already part of the plugin for legacy (non-LSP) mode, but it stopped working in LSP mdoe as the hack LSP server does not support quick fixes, so this PR restores the old behavior by adding the code actions.

