### PR TITLE
Correctly highlight default parameters on new lines

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -432,7 +432,7 @@
         },
         {
           "begin": "(?xi)\n\\s*(&)?      # Reference\n\\s*((\\$+)[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)  # The variable name",
-          "end": "(?xi)\n\\s*(?=,|\\)|/[/*]|\\#|$) # A closing parentheses (end of argument list) or a comma or a comment",
+          "end": "(?xi)\n\\s*(?=,|\\)|$) # A closing parentheses (end of argument list) or a comma",
           "beginCaptures": {
             "1": {
               "name": "storage.modifier.reference.php"
@@ -446,11 +446,16 @@
           },
           "patterns": [
             {
-              "match": "=",
-              "name": "keyword.operator.assignment.php"
-            },
-            {
-              "include": "#language"
+              "begin": "(=)",
+              "end": "(?=,|\\))",
+              "beginCaptures": {
+                "1": {
+                  "name": "keyword.operator.assignment.php.zz"
+                }
+              },
+              "patterns": [{
+                "include": "#language"
+              }]
             }
           ]
         }

--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -450,7 +450,7 @@
               "end": "(?=,|\\))",
               "beginCaptures": {
                 "1": {
-                  "name": "keyword.operator.assignment.php.zz"
+                  "name": "keyword.operator.assignment.php"
                 }
               },
               "patterns": [{

--- a/syntaxes/test/default_param_new_line.hack
+++ b/syntaxes/test/default_param_new_line.hack
@@ -1,0 +1,8 @@
+class Foo {
+  public static function bar(
+    mixed $arg =
+        'baz(biz //")'
+  ): string {
+    return "foo";
+  }
+}


### PR DESCRIPTION
Previously, we assumed that default parameters came after `=` on the same line. This isn't always true, especially when functions have large numbers of parameters.

Before:

![Screenshot 2021-06-18 at 17 40 44](https://user-images.githubusercontent.com/70800/122625887-58c7f480-d05c-11eb-80c3-04696166a0b8.png)

After:

![Screenshot 2021-06-18 at 17 41 56](https://user-images.githubusercontent.com/70800/122625934-7eed9480-d05c-11eb-9695-4565bdb1f51b.png)

