### PR TITLE
Remove JSON comments

### DIFF
--- a/hack.configuration.json
+++ b/hack.configuration.json
@@ -1,17 +1,13 @@
 {
   "comments": {
-    // symbol used for single line comment. Remove this entry if your language does not support line comments
     "lineComment": "//",
-    // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
     "blockComment": ["/*", "*/"]
   },
-  // symbols used as brackets
   "brackets": [
     ["{", "}"],
     ["[", "]"],
     ["(", ")"]
   ],
-  // symbols that are auto closed when typing
   "autoClosingPairs": [
     ["{", "}"],
     ["[", "]"],
@@ -19,7 +15,6 @@
     ["\"", "\""],
     ["'", "'"]
   ],
-  // symbols that that can be used to surround a selection
   "surroundingPairs": [
     ["{", "}"],
     ["[", "]"],


### PR DESCRIPTION
VS Code complains about JSON comments when starting a debug instance with the Hack extension.