### PR TITLE
Highlight class names in new expression tree syntax

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -263,6 +263,21 @@
         }
       ]
     },
+    "expression-trees": {
+      "begin": "(?=[a-zA-Z_0-9\\\\]*[A-Z_][a-zA-Z0-9_]*`)",
+      "end": "([A-Z_][a-zA-Z0-9_]*)`",
+      "comment": "match \\foo\\bar\\MyClass`baz` without capturing, then capture MyClass as a class name.",
+      "endCaptures": {
+        "1": {
+          "name": "support.class.php.expression-tree"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#namespace"
+        }
+      ]
+    },
     "constants": {
       "patterns": [
         {
@@ -1302,6 +1317,9 @@
               "include": "#language"
             }
           ]
+        },
+        {
+          "include": "#expression-trees"
         },
         {
           "include": "#constants"


### PR DESCRIPTION
Hack is exploring expression trees, and it'd be great to have highlighting for this new syntax ready to go.

Given the code

```
$x = Foo`1 + 2`;
```

highlight `Foo` as a type.

Before:

![Screenshot 2021-07-20 at 18 33 39](https://user-images.githubusercontent.com/70800/126417103-5375a4b9-4fca-48e5-88b0-c6f5d960411a.png)

After:

![Screenshot 2021-07-20 at 18 30 48](https://user-images.githubusercontent.com/70800/126417056-740c0d0f-0e40-496c-88ef-b09586d4e61e.png)

