### PR TITLE
Remove trust mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ This extension adds the following Visual Studio Code settings. These can be set 
 - `hack.hhastPath`: Use an alternate `hhast-lint` path. Can be abolute or relative to workspace root (default: `vendor/bin/hhast-lint`).
 - `hack.hhastArgs`: Optional list of arguments passed to hhast-lint executable.
 - `hack.hhastLintMode`: Whether to lint the entire project (`whole-project`) or just the open files (`open-files`).
-- `hack.rememberedWorkspaces`: Workspaces where whether or not to run custom Hack executables (e.g. hhast-lint) has been remembered. **Note:** This config can only be defined in VS Code global (user) settings.
 
 ### Remote Development
 

--- a/package.json
+++ b/package.json
@@ -245,18 +245,6 @@
           "default": null,
           "description": "Whether to lint the entire project or just the open files"
         },
-        "hack.rememberedWorkspaces": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string",
-            "enum": [
-              "trusted",
-              "untrusted"
-            ]
-          },
-          "default": {},
-          "description": "Workspaces where whether or not to run custom Hack executables (e.g. hhast-lint) has been remembered"
-        },
         "hack.remote.enabled": {
           "type": "boolean",
           "default": false,

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -31,27 +31,6 @@ export const hhastPath =
   hackConfig.get<string>("hhastPath") || "/vendor/bin/hhast-lint";
 export const hhastArgs = hackConfig.get<string[]>("hhastArgs", []);
 
-// Use the global configuration so that a project can't both provide a malicious hhast-lint executable and whitelist itself in $project/.vscode/settings.json
-const hhastRemembered:
-  | { globalValue?: { [key: string]: "trusted" | "untrusted" } }
-  | undefined = hackConfig.inspect("rememberedWorkspaces");
-export const hhastRememberedWorkspaces: {
-  [key: string]: "trusted" | "untrusted";
-} = hhastRemembered ? hhastRemembered.globalValue || {} : {};
-
-export async function rememberHhastWorkspace(
-  newWorkspace: string,
-  trust: "trusted" | "untrusted"
-) {
-  const remembered = hhastRememberedWorkspaces;
-  remembered[newWorkspace] = trust;
-  await hackConfig.update(
-    "rememberedWorkspaces",
-    remembered,
-    vscode.ConfigurationTarget.Global
-  );
-}
-
 export const remoteEnabled = hackConfig.get<boolean>("remote.enabled", false);
 export const remoteType: "ssh" | "docker" | undefined = hackConfig.get(
   "remote.type",

--- a/src/LSPHHASTLint.ts
+++ b/src/LSPHHASTLint.ts
@@ -64,37 +64,7 @@ export class LSPHHASTLint {
       return;
     }
 
-    const remembered = config.hhastRememberedWorkspaces[workspace];
-    if (remembered === "trusted") {
-      await new LSPHHASTLint(context, hhastPath).run();
-      return;
-    } else if (remembered === "untrusted") {
-      return;
-    }
-
-    const result = await vscode.window.showWarningMessage(
-      `Do you want to use ${hhastPath} to lint? This has the same security risks as executing any other code in the repository.`,
-      {},
-      "Yes",
-      "Always",
-      "No",
-      "Never"
-    );
-    switch (result) {
-      // @ts-ignore: Fallthrough case in switch
-      case "Always":
-        await config.rememberHhastWorkspace(workspace, "trusted");
-      case "Yes":
-        await new LSPHHASTLint(context, hhastPath).run();
-        break;
-      // @ts-ignore: Fallthrough case in switch
-      case "Never":
-        await config.rememberHhastWorkspace(workspace, "untrusted");
-      case "No":
-        return;
-      default:
-        return;
-    }
+    await new LSPHHASTLint(context, hhastPath).run();
   }
 
   public async run(): Promise<void> {


### PR DESCRIPTION
Essentially the same feature was added directly to VSCode, so this is
now a duplicate prompt.

fixes #126

https://code.visualstudio.com/docs/editor/workspace-trust
