### PR TITLE
Remove `exit`, `die` and `endif` as keywords

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -877,7 +877,7 @@
               "name": "keyword.control.php"
             }
           },
-          "match": "\\s*\\b((break|c(ase|ontinue)|d(e(clare|fault)|ie|o)|e(lse(if)?|nd(declare|for(each)?|if|switch|while)|xit)|for(each)?|if|return|switch|use|while))\\b"
+          "match": "\\s*\\b((break|c(ase|ontinue)|d(e(clare|fault)|o)|e(lse|nd(declare|for(each)?|switch|while))|for(each)?|if|return|switch|use|while))\\b"
         },
         {
           "begin": "(?i)\\b((?:require|include)(?:_once)?)\\b\\s*",


### PR DESCRIPTION
`exit` and `die` have not valid syntax for a long time, and `endif`
was removed recently.

Tested by starting VS Code and confirming that this syntax is no longer highlighted:

![Screenshot 2022-04-27 at 18 23 53](https://user-images.githubusercontent.com/70800/165657956-22152d71-989d-4d37-addb-fdd67f8abb15.png)
