### PR TITLE
Fix workspace and remote path mapping

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -5,7 +5,12 @@
 import * as vscode from "vscode";
 import * as config from "./Config";
 
-const localPath = vscode.Uri.file(config.localWorkspacePath).toString();
+const localPath = getUriFilePath(config.localWorkspacePath);
+const remotePath = getUriFilePath(config.remoteWorkspacePath);
+
+function getUriFilePath(path: string|undefined): string {
+  return path ? vscode.Uri.file(path).toString() : '';
+}
 
 /**
  * Converts a local workspace URI to a file path string (with or without scheme) to pass to
@@ -17,7 +22,6 @@ export const mapFromWorkspaceUri = (file: vscode.Uri): string => {
   if (!config.remoteEnabled || !config.remoteWorkspacePath) {
     return file.toString();
   }
-  const remotePath = vscode.Uri.file(config.remoteWorkspacePath).toString();
   return file
     .toString()
     .replace(localPath, remotePath);
@@ -32,8 +36,8 @@ export const mapToWorkspaceUri = (file: string): vscode.Uri => {
   let filePath = file;
   if (config.remoteEnabled && config.remoteWorkspacePath) {
     filePath = filePath.replace(
-      config.remoteWorkspacePath,
-      config.localWorkspacePath
+      remotePath,
+      localPath
     );
   }
   if (filePath.startsWith("file://")) {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -5,6 +5,8 @@
 import * as vscode from "vscode";
 import * as config from "./Config";
 
+const localPath = vscode.Uri.file(config.localWorkspacePath).toString();
+
 /**
  * Converts a local workspace URI to a file path string (with or without scheme) to pass to
  * the typechecker. Path is mapped to an alternate workspace root if configured.
@@ -15,9 +17,10 @@ export const mapFromWorkspaceUri = (file: vscode.Uri): string => {
   if (!config.remoteEnabled || !config.remoteWorkspacePath) {
     return file.toString();
   }
+  const remotePath = vscode.Uri.file(config.remoteWorkspacePath).toString();
   return file
     .toString()
-    .replace(config.localWorkspacePath, config.remoteWorkspacePath);
+    .replace(localPath, remotePath);
 };
 
 /**


### PR DESCRIPTION
This PR fixes two cases when working with Hack lang projects on Windows environment.

1. A Hack lang project is cloned locally on the file system, e.g. `d:\projects\hack-app`.
2. A Hack lang project is cloned inside WSL environment.

In both cases there will be wrong mapping between a local workspace path and remote one. 

In the first case the Windows directory separators are used in the path:
```
in the src/Utils.ts
file.toString() = "file:///c%3A/Users/user/Documents/Projects/hacklang/test"
config.remoteWorkspacePath = "c:\Users\user\Documents\Projects\hacklang\test"
```

In the second, a hostname `wsl.localhost` is added to the local workspace path:
```
in the src/Utils.ts:
file.toString() = "file://wsl.localhost/Ubuntu/home/user/git/test"
config.remoteWorkspacePath = "\\wsl.localhost\Ubuntu\home\user\git\test"
```

To fix the mapping, the local workspace is converted to an uri path and then replaced by the remoted path which is already converted too.

Closes #136 