### PR TITLE
Add syntax highlighting for enums

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -719,6 +719,27 @@
           ]
         },
         {
+          "begin": "(?i)^\\s*(enum)\\s*([a-z0-9_]+)\\s*:?",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.enum.php"
+            },
+            "2": {
+              "name": "entity.name.type.enum.php"
+            }
+          },
+          "end": "\\{",
+          "name": "meta.enum.php",
+          "patterns": [
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#type-annotation"
+            }
+          ]
+        },
+        {
           "begin": "(?i)^\\s*(trait)\\s+([a-z0-9_]+)\\s*",
           "beginCaptures": {
             "1": {

--- a/syntaxes/test/enums.hack
+++ b/syntaxes/test/enums.hack
@@ -1,0 +1,7 @@
+enum SimpleEnum: int as arraykey {
+  X = 1;
+  Y = 2;
+  Z = 3;
+}
+
+enum ComplicatedEnum: classname<Foo> as classname<Bar> {}


### PR DESCRIPTION
Before:

<img width="499" alt="Screenshot 2022-08-02 at 16 21 39" src="https://user-images.githubusercontent.com/70800/182501631-ca31a99e-bb2f-4227-8e14-e8106cd2ed66.png">

After:

<img width="508" alt="Screenshot 2022-08-02 at 16 19 01" src="https://user-images.githubusercontent.com/70800/182501648-99dd4bbb-ea1f-4fd0-b488-378a196d8f27.png">

Closes #128.