### PR TITLE
Add syntax highlighting for enum classes

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -698,6 +698,31 @@
           ]
         },
         {
+          "begin": "(?i)^\\s*(enum)\\s*(class)\\s+([a-z0-9_]+)\\s*:?",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.modifier.php"
+            },
+            "2": {
+              "name": "storage.type.class.enum.php"
+            },
+            "3": {
+              "name": "entity.name.type.class.enum.php"
+            }
+          },
+          "end": "(?=[{])",
+          "name": "meta.class.enum.php",
+          "patterns": [
+            {
+              "match": "\\b(extends)\\b",
+              "name": "storage.modifier.extends.php"
+            },
+            {
+              "include": "#type-annotation"
+            }
+          ]
+        },
+        {
           "begin": "(?i)^\\s*(enum)\\s*([a-z0-9_]+)\\s*:?",
           "beginCaptures": {
             "1": {

--- a/syntaxes/test/enum_classes.hack
+++ b/syntaxes/test/enum_classes.hack
@@ -1,0 +1,9 @@
+enum class SimpleEnumClass: mixed {
+  int X = 42;
+  string S = 'foo';
+}
+
+enum class WithInheritance: IFoo extends BaseFoo {
+}
+
+


### PR DESCRIPTION
Current highlighting of the included test file:

![Screenshot 2022-08-08 at 12 15 25](https://user-images.githubusercontent.com/70800/183497842-979c2a37-9cde-4528-89c7-498826f119a0.png)

After this PR:

![Screenshot 2022-08-08 at 12 14 22](https://user-images.githubusercontent.com/70800/183497892-80f8c969-a740-4e40-b6bf-490c968dad83.png)

(Note that this branch includes the commit from #140, so I suggest you merge that one first.)