### PR TITLE
Require a space after the enum keyword

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -698,7 +698,7 @@
           ]
         },
         {
-          "begin": "(?i)^\\s*(enum)\\s*(class)\\s+([a-z0-9_]+)\\s*:?",
+          "begin": "(?i)^\\s*(enum)\\s+(class)\\s+([a-z0-9_]+)\\s*:?",
           "beginCaptures": {
             "1": {
               "name": "storage.modifier.php"
@@ -723,7 +723,7 @@
           ]
         },
         {
-          "begin": "(?i)^\\s*(enum)\\s*([a-z0-9_]+)\\s*:?",
+          "begin": "(?i)^\\s*(enum)\\s+([a-z0-9_]+)\\s*:?",
           "beginCaptures": {
             "1": {
               "name": "storage.type.enum.php"

--- a/syntaxes/test/enums.hack
+++ b/syntaxes/test/enums.hack
@@ -2,6 +2,8 @@ enum SimpleEnum: int as arraykey {
   X = 1;
   Y = 2;
   Z = 3;
+  ENUM_FOO = 1;
+  ENUM_CLASS_BAR = 2;
 }
 
 enum ComplicatedEnum: classname<Foo> as classname<Bar> {}


### PR DESCRIPTION
This stops us confusing enum declarations with enum values that happen
to start `enum_foo`.

Before:

<img width="342" alt="Screenshot 2022-08-22 at 14 58 05" src="https://user-images.githubusercontent.com/70800/186026015-261e1933-db47-4194-a76c-d11d00db2fc6.png">

After:

<img width="314" alt="Screenshot 2022-08-22 at 14 56 24" src="https://user-images.githubusercontent.com/70800/186026035-76d7b25b-247c-4a2e-ad40-0c354d8bb0fd.png">