### PR TITLE
Highlight await and concurrent

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -339,11 +339,7 @@
       "name": "support.type.php",
       "patterns": [
         {
-          "match": "\\barray\\b",
-          "name": "support.type.array.php"
-        },
-        {
-          "match": "\\b(?:bool|int|float|string|array|resource|mixed|arraykey|nonnull|dict|vec|keyset)\\b",
+          "match": "\\b(?:bool|int|float|string|resource|mixed|arraykey|nonnull|dict|vec|keyset)\\b",
           "name": "support.type.php"
         },
         {
@@ -410,16 +406,13 @@
           "include": "#type-annotation"
         },
         {
-          "begin": "(?xi)\n\\s*(&)?      # Reference\n\\s*((\\$+)[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)  # The variable name",
+          "begin": "(?xi)((\\$+)[a-z_\\x{7f}-\\x{ff}][a-z0-9_\\x{7f}-\\x{ff}]*)  # The variable name",
           "end": "(?xi)\n\\s*(?=,|\\)|$) # A closing parentheses (end of argument list) or a comma",
           "beginCaptures": {
             "1": {
-              "name": "storage.modifier.reference.php"
-            },
-            "2": {
               "name": "variable.other.php"
             },
-            "3": {
+            "2": {
               "name": "punctuation.definition.variable.php"
             }
           },
@@ -902,7 +895,7 @@
               "name": "keyword.control.php"
             }
           },
-          "match": "\\s*\\b((break|c(ase|ontinue)|d(e(clare|fault)|o)|e(lse|nd(declare|for(each)?|switch|while))|for(each)?|if|return|switch|use|while))\\b"
+          "match": "\\s*\\b(break|c(ase|ontinue)|default|do|else|for(each)?|if|return|switch|use|while)\\b"
         },
         {
           "begin": "(?i)\\b((?:require|include)(?:_once)?)\\b\\s*",
@@ -973,13 +966,10 @@
           "name": "keyword.control.exception.php"
         },
         {
-          "begin": "(?i)\\b(function)\\s*(&\\s*)?(?=\\()",
+          "begin": "(?i)\\b(function)\\s*(?=\\()",
           "beginCaptures": {
             "1": {
               "name": "storage.type.function.php"
-            },
-            "2": {
-              "name": "storage.modifier.reference.php"
             }
           },
           "end": "\\{|\\)",
@@ -1042,7 +1032,7 @@
           ]
         },
         {
-          "begin": "(?x)\n\\s*((?:(?:final|abstract|public|private|protected|static|async)\\s+)*)\n(function)\n(?:\\s+|(\\s*&\\s*))\n(?:\n  (__(?:call|construct|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic|dispose|disposeAsync)(?=[^a-zA-Z0-9_\\x7f-\\xff]))\n  |\n  ([a-zA-Z0-9_]+)\n)",
+          "begin": "(?x)\n\\s*((?:(?:final|abstract|public|private|protected|static|async)\\s+)*)\n(function)\n(?:\\s+)\n(?:\n  (__(?:call|construct|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic|dispose|disposeAsync)(?=[^a-zA-Z0-9_\\x7f-\\xff]))\n  |\n  ([a-zA-Z0-9_]+)\n)",
           "beginCaptures": {
             "1": {
               "patterns": [
@@ -1056,15 +1046,12 @@
               "name": "storage.type.function.php"
             },
             "3": {
-              "name": "storage.modifier.reference.php"
-            },
-            "4": {
               "name": "support.function.magic.php"
             },
-            "5": {
+            "4": {
               "name": "entity.name.function.php"
             },
-            "6": {
+            "5": {
               "name": "meta.function.generics.php"
             }
           },
@@ -1226,10 +1213,6 @@
         {
           "match": "\\|>",
           "name": "keyword.operator.pipe.php"
-        },
-        {
-          "match": "(@)",
-          "name": "keyword.operator.error-control.php"
         },
         {
           "match": "(!==|!=|===|==)",
@@ -1427,33 +1410,6 @@
         {
           "match": "=",
           "name": "keyword.operator.assignment.php"
-        },
-        {
-          "match": "&(?=\\s*\\$)",
-          "name": "storage.modifier.reference.php"
-        },
-        {
-          "begin": "(array)\\s*(\\()",
-          "beginCaptures": {
-            "1": {
-              "name": "support.function.construct.php"
-            },
-            "2": {
-              "name": "punctuation.definition.array.begin.php"
-            }
-          },
-          "end": "\\)",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.array.end.php"
-            }
-          },
-          "name": "meta.array.php",
-          "patterns": [
-            {
-              "include": "#parameter-default-types"
-            }
-          ]
         },
         {
           "include": "#instantiation"

--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -895,7 +895,7 @@
               "name": "keyword.control.php"
             }
           },
-          "match": "\\s*\\b(break|c(ase|ontinue)|default|do|else|for(each)?|if|return|switch|use|while)\\b"
+          "match": "\\s*\\b(await|break|c(ase|ontinue)|concurrent|default|do|else|for(each)?|if|return|switch|use|while)\\b"
         },
         {
           "begin": "(?i)\\b((?:require|include)(?:_once)?)\\b\\s*",

--- a/syntaxes/test/async.hack
+++ b/syntaxes/test/async.hack
@@ -1,0 +1,10 @@
+async function gen_foo(): Awaitable<int> {
+  return 1;
+}
+
+async function gen_bar(): Awaitable<void> {
+  concurrent {
+    $x = await gen_foo(1);
+    $y = await gen_foo(2);
+  }
+}


### PR DESCRIPTION
Treat `await` and `concurrent` as keywords, consistent with `return` or `foreach`.

Before:

![Screenshot 2022-08-31 at 14 51 51](https://user-images.githubusercontent.com/70800/187792215-c416aa1b-1ac9-4e65-8892-9bdfb92f4f90.png)

After:

![Screenshot 2022-08-31 at 14 51 10](https://user-images.githubusercontent.com/70800/187792192-b473094b-8392-4a25-ab5d-1ddc5929c9f8.png)

I've also removed a few references to obsolete syntax. See the first commit.