### PR TITLE
Add colorization for new module syntax

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -605,9 +605,12 @@
       "name": "meta.function-call.invoke.php"
     },
     "interface": {
-      "begin": "^(?i)\\b(interface)\\b",
+      "begin": "^(?i)\\s*(?:(public|internal)?\\s+)(interface)\\b",
       "beginCaptures": {
         "1": {
+          "name": "storage.modifier.php"
+        },
+        "2": {
           "name": "storage.type.interface.php"
         }
       },
@@ -658,12 +661,15 @@
           "include": "#interface"
         },
         {
-          "begin": "(?xi)\n^\\s*\n(type|newtype)\n\\s+\n([a-z0-9_]+)",
+          "begin": "(?xi)\n^\\s*\n(?:(module)\\s*)?(type|newtype)\n\\s+\n([a-z0-9_]+)",
           "beginCaptures": {
             "1": {
               "name": "storage.type.typedecl.php"
             },
             "2": {
+              "name": "storage.type.typedecl.php"
+            },
+            "3": {
               "name": "entity.name.type.typedecl.php"
             }
           },
@@ -691,15 +697,18 @@
           ]
         },
         {
-          "begin": "(?i)^\\s*(enum)\\s+(class)\\s+([a-z0-9_]+)\\s*:?",
+          "begin": "(?i)^\\s*(?:(public|internal)?\\s+)(enum)\\s+(class)\\s+([a-z0-9_]+)\\s*:?",
           "beginCaptures": {
             "1": {
               "name": "storage.modifier.php"
             },
             "2": {
-              "name": "storage.type.class.enum.php"
+              "name": "storage.modifier.php"
             },
             "3": {
+              "name": "storage.type.class.enum.php"
+            },
+            "4": {
               "name": "entity.name.type.class.enum.php"
             }
           },
@@ -716,12 +725,15 @@
           ]
         },
         {
-          "begin": "(?i)^\\s*(enum)\\s+([a-z0-9_]+)\\s*:?",
+          "begin": "(?i)^\\s*(?:(public|internal)?\\s+)(enum)\\s+([a-z0-9_]+)\\s*:?",
           "beginCaptures": {
             "1": {
-              "name": "storage.type.enum.php"
+              "name": "storage.modifier.php"
             },
             "2": {
+              "name": "storage.type.enum.php"
+            },
+            "3": {
               "name": "entity.name.type.enum.php"
             }
           },
@@ -737,12 +749,15 @@
           ]
         },
         {
-          "begin": "(?i)^\\s*(trait)\\s+([a-z0-9_]+)\\s*",
+          "begin": "(?i)^\\s*(?:(public|internal)?\\s+)(trait)\\s+([a-z0-9_]+)\\s*",
           "beginCaptures": {
             "1": {
-              "name": "storage.type.trait.php"
+              "name": "storage.modifier.php"
             },
             "2": {
+              "name": "storage.type.trait.php"
+            },
+            "3": {
               "name": "entity.name.type.class.php"
             }
           },
@@ -757,6 +772,45 @@
             },
             {
               "include": "#implements"
+            }
+          ]
+        },
+        {
+          "begin": "^\\s*(new)\\s+(module)\\s+([A-Za-z0-9_\\.]+)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.module.php"
+            },
+            "2": {
+              "name": "storage.type.module.php"
+            },
+            "3": {
+              "name": "entity.name.type.module.php"
+            }
+          },
+          "end": "(?=[{])",
+          "name": "meta.module.php",
+          "patterns": [
+            {
+              "include": "#comments"
+            }
+          ]
+        },
+        {
+          "begin": "^\\s*(module)\\s+([A-Za-z0-9_\\.]+)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.other.module.php"
+            },
+            "2": {
+              "name": "entity.name.type.module.php"
+            }
+          },
+          "end": "$|(?=[\\s;])",
+          "name": "meta.use.module.php",
+          "patterns": [
+            {
+              "include": "#comments"
             }
           ]
         },
@@ -824,18 +878,20 @@
           ]
         },
         {
-          "begin": "(?i)^\\s*(abstract|final)?\\s*(abstract|final)?\\s*(class)\\s+([a-z0-9_]+)\\s*",
+          "begin": "(?i)^\\s*((?:(?:final|abstract|public|internal)\\s+)*)(class)\\s+([a-z0-9_]+)\\s*",
           "beginCaptures": {
             "1": {
-              "name": "storage.modifier.php"
+              "patterns": [
+                {
+                  "match": "final|abstract|public|internal",
+                  "name": "storage.modifier.php"
+                }
+              ]
             },
             "2": {
-              "name": "storage.modifier.php"
-            },
-            "3": {
               "name": "storage.type.class.php"
             },
-            "4": {
+            "3": {
               "name": "entity.name.type.class.php"
             }
           },
@@ -966,9 +1022,12 @@
           "name": "keyword.control.exception.php"
         },
         {
-          "begin": "(?i)\\b(function)\\s*(?=\\()",
+          "begin": "(?i)\\s*(?:(public|internal)?\\s+)(function)\\s*(?=\\()",
           "beginCaptures": {
             "1": {
+              "name": "storage.modifier.php"
+            },
+            "2": {
               "name": "storage.type.function.php"
             }
           },
@@ -1032,12 +1091,12 @@
           ]
         },
         {
-          "begin": "(?x)\n\\s*((?:(?:final|abstract|public|private|protected|static|async)\\s+)*)\n(function)\n(?:\\s+)\n(?:\n  (__(?:call|construct|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic|dispose|disposeAsync)(?=[^a-zA-Z0-9_\\x7f-\\xff]))\n  |\n  ([a-zA-Z0-9_]+)\n)",
+          "begin": "(?x)\n\\s*((?:(?:final|abstract|public|private|protected|internal|static|async)\\s+)*)\n(function)\n(?:\\s+)\n(?:\n  (__(?:call|construct|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic|dispose|disposeAsync)(?=[^a-zA-Z0-9_\\x7f-\\xff]))\n  |\n  ([a-zA-Z0-9_]+)\n)",
           "beginCaptures": {
             "1": {
               "patterns": [
                 {
-                  "match": "final|abstract|public|private|protected|static|async",
+                  "match": "final|abstract|public|private|protected|internal|static|async",
                   "name": "storage.modifier.php"
                 }
               ]
@@ -1185,7 +1244,7 @@
           "name": "support.type.php"
         },
         {
-          "match": "(?i)\\b(global|abstract|const|extends|implements|final|p(r(ivate|otected)|ublic)|static)\\b",
+          "match": "(?i)\\b(global|abstract|const|extends|implements|final|p(r(ivate|otected)|ublic)|internal|static)\\b",
           "name": "storage.modifier.php"
         },
         {
@@ -1455,7 +1514,7 @@
               "name": "invalid.illegal.wrong-access-type.phpdoc.php"
             }
           },
-          "match": "^\\s*\\*\\s*(@access)\\s+((public|private|protected)|(.+))\\s*$"
+          "match": "^\\s*\\*\\s*(@access)\\s+((public|private|protected|internal)|(.+))\\s*$"
         },
         {
           "captures": {

--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -664,7 +664,7 @@
           "begin": "(?xi)\n^\\s*\n(?:(module)\\s*)?(type|newtype)\n\\s+\n([a-z0-9_]+)",
           "beginCaptures": {
             "1": {
-              "name": "storage.type.typedecl.php"
+              "name": "storage.modifier.php"
             },
             "2": {
               "name": "storage.type.typedecl.php"

--- a/syntaxes/test/modules.hack
+++ b/syntaxes/test/modules.hack
@@ -1,0 +1,42 @@
+module foo.bar.baz;
+
+new module foo.bar.baz {
+}
+
+module newtype x = y;
+
+internal interface foo {
+}
+
+public interface foo {
+}
+
+internal enum foo {
+}
+
+public enum foo {
+}
+
+internal enum class foo {
+}
+
+public enum class foo {
+}
+
+internal trait foo {
+    internal int $x;
+    internal function y(): void {
+    }
+}
+
+public trait foo {
+}
+
+internal class foo {
+    internal int $x;
+    internal function y(): void {
+    }
+}
+
+public class foo {
+}


### PR DESCRIPTION
This adds colorization for 
* module declarations (`new module {}`)
* module membership (`module x;`)
* 'internal types' and members
* `module newtype` module-scoped typedefs