### PR TITLE
Only highlight regular expressions in re"..." literals

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -1543,7 +1543,7 @@
       ]
     },
     "regex-double-quoted": {
-      "begin": "(?x)\n\"/ (?=(\\\\.|[^\"/])++/[imsxeADSUXu]*\")",
+      "begin": "(?x)\n(?<=re)\"/ (?=(\\\\.|[^\"/])++/[imsxeADSUXu]*\")",
       "beginCaptures": {
         "0": {
           "name": "punctuation.definition.string.begin.php"
@@ -1599,7 +1599,7 @@
       ]
     },
     "regex-single-quoted": {
-      "begin": "(?x)\n'/ (?=(\\\\.|[^'/])++/[imsxeADSUXu]*')",
+      "begin": "(?x)\n(?<=re)'/ (?=(\\\\.|[^'/])++/[imsxeADSUXu]*')",
       "beginCaptures": {
         "0": {
           "name": "punctuation.definition.string.begin.php"

--- a/syntaxes/test/interpolation.hack
+++ b/syntaxes/test/interpolation.hack
@@ -31,3 +31,13 @@ function single_quoted(): void {
   // No interpolation here.
   $x = 'foo $x';
 }
+
+function regex(): void {
+  // In a regular expression, we want to highlight metacharacters.
+  $x = re"/* foo */";
+  $x = re'/* foo */';
+
+  // Don't treat plain strings with / as regexps.
+  $x = "/* foo */";
+  $x = '/* foo */';
+}


### PR DESCRIPTION
Don't treat `"//"` as a regular expression if it isn't in a re literal.

I've also added some literals to the test files to exercise this:

<img width="512" alt="Screenshot 2022-09-29 at 15 37 57" src="https://user-images.githubusercontent.com/70800/193154601-7085d25c-7c95-46eb-850c-41d4a8d78ba7.png">


