### PR TITLE
Fix colorization for top-level declarations

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -605,7 +605,7 @@
       "name": "meta.function-call.invoke.php"
     },
     "interface": {
-      "begin": "^(?i)\\s*(?:(public|internal)?\\s+)(interface)\\b",
+      "begin": "^(?i)\\s*(?:(public|internal)\\s+)?(interface)\\b",
       "beginCaptures": {
         "1": {
           "name": "storage.modifier.php"
@@ -697,7 +697,7 @@
           ]
         },
         {
-          "begin": "(?i)^\\s*(?:(public|internal)?\\s+)(enum)\\s+(class)\\s+([a-z0-9_]+)\\s*:?",
+          "begin": "(?i)^\\s*(?:(public|internal)\\s+)?(enum)\\s+(class)\\s+([a-z0-9_]+)\\s*:?",
           "beginCaptures": {
             "1": {
               "name": "storage.modifier.php"
@@ -725,7 +725,7 @@
           ]
         },
         {
-          "begin": "(?i)^\\s*(?:(public|internal)?\\s+)(enum)\\s+([a-z0-9_]+)\\s*:?",
+          "begin": "(?i)^\\s*(?:(public|internal)\\s+)?(enum)\\s+([a-z0-9_]+)\\s*:?",
           "beginCaptures": {
             "1": {
               "name": "storage.modifier.php"
@@ -749,7 +749,7 @@
           ]
         },
         {
-          "begin": "(?i)^\\s*(?:(public|internal)?\\s+)(trait)\\s+([a-z0-9_]+)\\s*",
+          "begin": "(?i)^\\s*(?:(public|internal)\\s+)?(trait)\\s+([a-z0-9_]+)\\s*",
           "beginCaptures": {
             "1": {
               "name": "storage.modifier.php"
@@ -1022,7 +1022,7 @@
           "name": "keyword.control.exception.php"
         },
         {
-          "begin": "(?i)\\s*(?:(public|internal)?\\s+)(function)\\s*(?=\\()",
+          "begin": "(?i)\\s*(?:(public|internal)\\s+)?(function)\\s*(?=\\()",
           "beginCaptures": {
             "1": {
               "name": "storage.modifier.php"

--- a/syntaxes/test/modules.hack
+++ b/syntaxes/test/modules.hack
@@ -11,16 +11,25 @@ internal interface foo {
 public interface foo {
 }
 
+interface foo {
+}
+
 internal enum foo {
 }
 
 public enum foo {
 }
 
+enum foo {
+}
+
 internal enum class foo {
 }
 
 public enum class foo {
+}
+
+enum class foo {
 }
 
 internal trait foo {
@@ -32,6 +41,9 @@ internal trait foo {
 public trait foo {
 }
 
+trait foo {
+}
+
 internal class foo {
     internal int $x;
     internal function y(): void {
@@ -39,4 +51,16 @@ internal class foo {
 }
 
 public class foo {
+}
+
+class foo {
+}
+
+internal function foo(): void {
+}
+
+public function foo(): void {
+}
+
+function foo(): void {
 }


### PR DESCRIPTION
My previous PR to colorize modules had a subtle error which now causes the default case (i.e. no access modifiers) of top-level declarations to not colorize properly. This fixes it and adds test cases to ensure it works properly.