### PR TITLE
Update comment syntax in snippets

### DIFF
--- a/snippets/hack.json
+++ b/snippets/hack.json
@@ -2,7 +2,7 @@
   ".source.hack": {
     "function __construct": {
       "prefix": "con",
-      "body": "${1:public} function __construct($2) {\n\t${3:# code...;}$0\n}"
+      "body": "${1:public} function __construct($2) {\n\t${3:// code...;}$0\n}"
     },
     "Class Variable": {
       "prefix": "doc_v",
@@ -14,11 +14,11 @@
     },
     "class …": {
       "prefix": "class",
-      "body": "/**\n * $1\n */\nclass ${2:ClassName} ${3:extends ${4:AnotherClass}} {\n\t${5:public} function ${6:__construct}($7) {\n\t\t${0:# code...}\n\t}\n}\n"
+      "body": "/**\n * $1\n */\nclass ${2:ClassName} ${3:extends ${4:AnotherClass}} {\n\t${5:public} function ${6:__construct}($7) {\n\t\t${0:// code...}\n\t}\n}\n"
     },
     "trait …": {
       "prefix": "trait",
-      "body": "/**\n * $1\n */\ntrait ${2:TraitName} {\n\tfunction ${3:functionName}($4): $5 {\n\t\t${6:# code...}\n\t}\n}\n"
+      "body": "/**\n * $1\n */\ntrait ${2:TraitName} {\n\tfunction ${3:functionName}($4): $5 {\n\t\t${6:// code...}\n\t}\n}\n"
     },
     "const _ _ = _": {
       "prefix": "const",
@@ -26,7 +26,7 @@
     },
     "do … while …": {
       "prefix": "do",
-      "body": "do {\n\t${0:# code...}\n} while (${1:\\$a <= 10});"
+      "body": "do {\n\t${0:// code...}\n} while (${1:\\$a <= 10});"
     },
     "echo \"…\"": {
       "prefix": "echo",
@@ -34,31 +34,31 @@
     },
     "else …": {
       "prefix": "else",
-      "body": "else {\n\t${0:# code...}\n}"
+      "body": "else {\n\t${0:// code...}\n}"
     },
     "elseif …": {
       "prefix": "elseif",
-      "body": "else if (${1:condition}) {\n\t${0:# code...}\n}"
+      "body": "else if (${1:condition}) {\n\t${0:// code...}\n}"
     },
     "for …": {
       "prefix": "for",
-      "body": "for ($${1:i} = ${2:0}; $${1:i} < $3; $${1:i}++) { \n\t${0:# code...}\n}"
+      "body": "for ($${1:i} = ${2:0}; $${1:i} < $3; $${1:i}++) { \n\t${0:// code...}\n}"
     },
     "foreach …": {
       "prefix": "foreach",
-      "body": "foreach ($${1:variable} as $${2:key} ${3:=> $${4:value}}) {\n\t${0:# code...}\n}"
+      "body": "foreach ($${1:variable} as $${2:key} ${3:=> $${4:value}}) {\n\t${0:// code...}\n}"
     },
     "function …": {
       "prefix": "func",
-      "body": "${1:public }function ${2:functionName}(${3:$${4:value}${5:=''}})\n{\n\t${0:# code...}\n}"
+      "body": "${1:public }function ${2:functionName}(${3:$${4:value}${5:=''}})\n{\n\t${0:// code...}\n}"
     },
     "if … else …": {
       "prefix": "ifelse",
-      "body": "if (${1:condition}) {\n\t${2:# code...}\n} else {\n\t${3:# code...}\n}\n$0"
+      "body": "if (${1:condition}) {\n\t${2:// code...}\n} else {\n\t${3:// code...}\n}\n$0"
     },
     "if …": {
       "prefix": "if",
-      "body": "if (${1:condition}) {\n\t${0:# code...}\n}"
+      "body": "if (${1:condition}) {\n\t${0:// code...}\n}"
     },
     "$… = ( … ) ? … : …": {
       "prefix": "if?",
@@ -86,11 +86,11 @@
     },
     "switch …": {
       "prefix": "switch",
-      "body": "switch (${1:variable}) {\n\tcase '${2:value}':\n\t\t${3:# code...}\n\t\tbreak;\n\t$0\n\tdefault:\n\t\t${4:# code...}\n\t\tbreak;\n}"
+      "body": "switch (${1:variable}) {\n\tcase '${2:value}':\n\t\t${3:// code...}\n\t\tbreak;\n\t$0\n\tdefault:\n\t\t${4:// code...}\n\t\tbreak;\n}"
     },
     "case …": {
       "prefix": "case",
-      "body": "case '${1:variable}':\n\t${0:# code...}\n\tbreak;"
+      "body": "case '${1:variable}':\n\t${0:// code...}\n\tbreak;"
     },
     "$this->…": {
       "prefix": "this",
@@ -106,7 +106,7 @@
     },
     "while …": {
       "prefix": "while",
-      "body": "while (${1:$$a <= 10}) {\n\t${0:# code...}\n}"
+      "body": "while (${1:$$a <= 10}) {\n\t${0:// code...}\n}"
     }
   }
 }


### PR DESCRIPTION
Our hack snippets still use `#` to prefix comments, which haven't been supported since HHVM 4.133, per the docs: https://docs.hhvm.com/hack/source-code-fundamentals/comments

This PR simply replaces the `#` with `//` to use the current comment syntax.