### PR TITLE
Fix range in Oniguruma regex for Hack grammar (#159)

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -1091,7 +1091,7 @@
           ]
         },
         {
-          "begin": "(?x)\n\\s*((?:(?:final|abstract|public|private|protected|internal|static|async)\\s+)*)\n(function)\n(?:\\s+)\n(?:\n  (__(?:call|construct|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic|dispose|disposeAsync)(?=[^a-zA-Z0-9_\\x7f-\\xff]))\n  |\n  ([a-zA-Z0-9_]+)\n)",
+          "begin": "(?x)\n\\s*((?:(?:final|abstract|public|private|protected|internal|static|async)\\s+)*)\n(function)\n(?:\\s+)\n(?:\n  (__(?:call|construct|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic|dispose|disposeAsync)(?=[^a-zA-Z0-9_\\x7f-\\x{ff}]))\n  |\n  ([a-zA-Z0-9_]+)\n)",
           "beginCaptures": {
             "1": {
               "patterns": [


### PR DESCRIPTION
Fixes #159. See extended details there, but essentially, `\xHH` for values above `7F` doesn't the work the same in Oniguruma (the regex engine used by TextMate grammars) as in other regex engines. As a result, a standalone `\xff` is an invalid UTF-8 encoded byte value, rather than a valid code point value as it would be if using `\x{ff}`. So although this regex isn't throwing in Oniguruma due to loose error handling for encoded bytes that are never used in a valid UTF-8 encoded byte sequence (bytes `F5` through `FF`), this is in fact an invalid Oniguruma pattern.

This error is currently leading to edge case bugs in Oniguruma (code points above `FF` are not matched by this negated range) and preventing the Hack grammar from working with Shiki's JS engine (which has stricter error handling for this invalid Oniguruma pattern).