### PR TITLE
Fix invalid regex (fixes #159)

### DIFF
--- a/syntaxes/hack.json
+++ b/syntaxes/hack.json
@@ -1091,7 +1091,7 @@
           ]
         },
         {
-          "begin": "(?x)\n\\s*((?:(?:final|abstract|public|private|protected|internal|static|async)\\s+)*)\n(function)\n(?:\\s+)\n(?:\n  (__(?:call|construct|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic|dispose|disposeAsync)(?=[^a-zA-Z0-9_\\x7f-\\xff]))\n  |\n  ([a-zA-Z0-9_]+)\n)",
+          "begin": "(?x)\n\\s*((?:(?:final|abstract|public|private|protected|internal|static|async)\\s+)*)\n(function)\n(?:\\s+)\n(?:\n  (__(?:call|construct|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic|dispose|disposeAsync)(?=[^a-zA-Z0-9_\\x{7f}-\\x{ff}]))\n  |\n  ([a-zA-Z0-9_]+)\n)",
           "beginCaptures": {
             "1": {
               "patterns": [


### PR DESCRIPTION
See extended details at #159, but essentially, `\xHH` for values above `7F` doesn't work the same in Oniguruma (the regex engine used for TextMate grammars) as in other flavors of regex. As a result, a standalone unenclosed `\xff` like the one corrected here is an invalid UTF-8 encoded byte value, rather than a valid code point value as it would be if using the enclosed version `\x{ff}`.

This error is currently leading to highlighting bugs with some input strings (code points above `FF` are not matched by this negated range), and preventing the Hack grammar from working at all with [Shiki](https://shiki.style/)'s JS engine.

The adjacent `\x7f` that I also changed was already valid, but I changed it for consistency.

Note that this was the only place the invalid `\\x7f-\\xff` appeared, but the valid/correct version `\\x{7f}-\\x{ff}` already appears 28 times in the same file.