### PR TITLE
fix: nest paths filter under push and pull_request triggers

### DIFF
--- a/.github/workflows/linguist.yml
+++ b/.github/workflows/linguist.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - master
+    paths: ["syntaxes/hack.json", ".github/workflows/linguist.yml"]
   pull_request:
     branches:
       - master
-  paths: ["syntaxes/hack.json", ".github/workflows/linguist.yml"]
+    paths: ["syntaxes/hack.json", ".github/workflows/linguist.yml"]
 
 permissions:
   contents: read


### PR DESCRIPTION
The paths filter was a sibling of push/pull_request instead of nested under each, so it was ignored and the workflow ran on every push/PR rather than only when the grammar or workflow file changed.