### PR TITLE
fix: relax minimum supported VSCode version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,9 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore: "
+    # Ignore dependabot PRs for VSCode and Node bumps,
+    # since we want to control what version of VSCode we support,
+    # and the Node version is tied to the VSCode version.
+    ignore:
+      - dependency-name: "@types/node"
+      - dependency-name: "@types/vscode"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,10 @@
         "@commitlint/cli": "^20.5.0",
         "@commitlint/config-conventional": "^20.5.0",
         "@eslint/js": "^10.0.1",
-        "@types/node": "^24.1.0",
+        "@types/node": "^22.13.14",
         "@types/qunit": "^2.19.13",
         "@types/sinon": "^21.0.1",
-        "@types/vscode": "^1.109.0",
+        "@types/vscode": "^1.108.0",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.7.1",
         "esbuild": "^0.28.0",
@@ -39,7 +39,7 @@
         "typescript-eslint": "^8.58.1"
       },
       "engines": {
-        "vscode": "^1.109.0"
+        "vscode": "^1.108.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -1828,13 +1828,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.11.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.11.0.tgz",
-      "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -7639,9 +7639,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.4",
   "publisher": "pranayagarwal",
   "engines": {
-    "vscode": "^1.109.0"
+    "vscode": "^1.108.0"
   },
   "license": "MIT",
   "displayName": "Hack",
@@ -320,10 +320,10 @@
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
     "@eslint/js": "^10.0.1",
-    "@types/node": "^24.1.0",
+    "@types/node": "^22.13.14",
     "@types/qunit": "^2.19.13",
     "@types/sinon": "^21.0.1",
-    "@types/vscode": "^1.109.0",
+    "@types/vscode": "^1.108.0",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.7.1",
     "esbuild": "^0.28.0",


### PR DESCRIPTION
We recently increased our minimum VSCode version requirement to 1.109.0, but its adoption seems to be far from universal.
Drop it back to 1.108 or newer and disable Dependabot PRs for VSCode and Node dependencies.